### PR TITLE
Add JSON transfer demo and attacker JSON test to CSRF example

### DIFF
--- a/csrf/server-app.ts
+++ b/csrf/server-app.ts
@@ -18,6 +18,7 @@ fastify.get("/", function (request, reply) {
   <h1>App</h1>
   <ul>
     <li><a href="/transfer-demo">Transfer Demo</a></li>
+    <li><a href="/transfer-json-demo">Transfer JSON Demo</a></li>
     <li><a href="/json">/json</a></li>
   </ul>
 </body>
@@ -46,6 +47,36 @@ fastify.get("/transfer-demo", function (request, reply) {
 </html>`);
 });
 
+
+fastify.get("/transfer-json-demo", function (request, reply) {
+  reply.header("Content-Type", "text/html; charset=utf-8").send(`<html>
+<head>
+  <title>Transfer JSON Demo</title>
+</head>
+<body>
+  <h1>Transfer JSON Demo</h1>
+  <p>This sends JSON and a custom header, so a cross-origin request requires a CORS pre-flight.</p>
+  <button type="button" id="send-transfer">Send money</button>
+
+  <script>
+    const button = document.getElementById("send-transfer");
+    button.addEventListener("click", async () => {
+      const response = await fetch("/transfer-json", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Transfer-Intent": "manual",
+        },
+        body: JSON.stringify({ to: "alice", amount: "100" }),
+      });
+
+      document.body.insertAdjacentHTML("beforeend", await response.text());
+    });
+  </script>
+</body>
+</html>`);
+});
+
 type TransferBody = {
   to?: string;
   amount?: string;
@@ -65,6 +96,25 @@ fastify.post("/transfer", function (request, reply) {
   <p>Transferred ${amount} to ${to}.</p>
 </body>
 </html>`);
+});
+
+
+
+type TransferJsonBody = {
+  to?: string;
+  amount?: string;
+};
+
+// This is a non-simple request for Same-Origin Policy purposes - JSON and custom headers cause a pre-flight for cross-origin requests.
+fastify.post("/transfer-json", function (request, reply) {
+  const body = request.body as TransferJsonBody;
+  const to = body.to ?? "";
+  const amount = body.amount ?? "";
+
+  reply.header("Content-Type", "text/html; charset=utf-8").send(`<section>
+  <h2>Transfer JSON Complete</h2>
+  <p>Transferred ${amount} to ${to}.</p>
+</section>`);
 });
 
 fastify.get("/json", function (request, reply) {

--- a/csrf/server-attacker.ts
+++ b/csrf/server-attacker.ts
@@ -19,6 +19,39 @@ fastify.get("/", function (request, reply) {
     <input type="hidden" name="amount" value="1000" />
     <button type="submit">Claim reward</button>
   </form>
+
+  <hr />
+  <h2>Try the non-simple transfer endpoint</h2>
+  <p>
+    This uses JSON and a custom header, so the browser should send a pre-flight
+    request before attempting the cross-origin POST.
+  </p>
+  <button type="button" id="claim-json-reward">Claim JSON reward</button>
+  <pre id="json-result"></pre>
+
+  <script>
+    const button = document.getElementById("claim-json-reward");
+    const result = document.getElementById("json-result");
+
+    button.addEventListener("click", async () => {
+      result.textContent = "Sending cross-origin JSON transfer...";
+
+      try {
+        const response = await fetch("http://localhost:3000/transfer-json", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Transfer-Intent": "attacker",
+          },
+          body: JSON.stringify({ to: "mallory", amount: "1000" }),
+        });
+
+        result.textContent = "Response status: " + response.status;
+      } catch (error) {
+        result.textContent = "Request failed: " + error;
+      }
+    });
+  </script>
 </body>
 </html>`);
 });


### PR DESCRIPTION
### Motivation

- Demonstrate a non-simple cross-origin request (JSON body + custom header) for the CSRF demo so the example shows CORS pre-flight behavior in addition to a simple form POST.

### Description

- Added a `/transfer-json-demo` HTML page and linked it from the root to demonstrate sending JSON from the browser to the app.
- Implemented a `POST /transfer-json` handler in `server-app.ts` that accepts JSON `to` and `amount` fields and returns an HTML fragment confirmation.
- Added a JSON transfer test UI to the attacker site in `server-attacker.ts` that performs a cross-origin `fetch` with `Content-Type: application/json` and a custom `X-Transfer-Intent` header to trigger a pre-flight.
- Kept existing `/transfer` form POST handler for the simple (same-origin/simple) request example.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3129697a083278108be6a34348380)