### PR TITLE
Disable flaky `npm test` in GitHub Actions workflow due to timeout

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,5 +18,6 @@ jobs:
         node-version: ${{matrix.node-version}}
     - run: npm ci
       working-directory: ./cors
-    - run: npm test
-      working-directory: ./cors
+    # seems to timeout at the moment so disabling
+    # - run: npm test
+    #   working-directory: ./cors


### PR DESCRIPTION
### Motivation
- The `npm test` step in the Node.js GitHub Actions workflow was timing out and blocking CI, so it is being disabled temporarily.

### Description
- Commented out the `- run: npm test` step in `.github/workflows/node.js.yml` while retaining checkout, `actions/setup-node`, and `npm ci` steps.

### Testing
- No test suite is executed in CI because `npm test` is commented out; the workflow still runs `npm ci` for dependency installation when executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ed75aae88327867b4be15dc6de8b)