### PR TITLE
Implement edge-managed forwarding headers in reverse proxy

### DIFF
--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -163,6 +163,58 @@ test("client method, headers and body are sent to backend", async () => {
   expect(response.body).toBe("hello from client backend modified!");
 });
 
+test("replaces forwarding headers and preserves other headers", async () => {
+  await createBackendServer({
+    port: 3000,
+    body: "unused",
+    handleRequest: (request, response) => {
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "application/json");
+      response.end(
+        JSON.stringify({
+          forwarded: request.headers.forwarded,
+          xForwardedFor: request.headers["x-forwarded-for"],
+          xForwardedHost: request.headers["x-forwarded-host"],
+          xForwardedProto: request.headers["x-forwarded-proto"],
+          xCustomHeader: request.headers["x-custom-header"],
+        }),
+      );
+    },
+  });
+
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backendByHostname: {
+      "example.com": "http://localhost:3000",
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "example.com:1234",
+      Forwarded: 'for="198.51.100.77";proto=https',
+      "X-Forwarded-For": "198.51.100.77",
+      "X-Forwarded-Host": "attacker.example",
+      "X-Forwarded-Proto": "https",
+      "X-Custom-Header": "keep-me",
+    },
+  });
+
+  expect(response.statusCode).toBe(200);
+  const forwardedHeaders = JSON.parse(response.body) as {
+    forwarded?: string;
+    xForwardedFor?: string;
+    xForwardedHost?: string;
+    xForwardedProto?: string;
+    xCustomHeader?: string;
+  };
+
+  expect(forwardedHeaders.forwarded).toBeUndefined();
+  expect(forwardedHeaders.xForwardedFor).toBe("::ffff:127.0.0.1");
+  expect(forwardedHeaders.xForwardedHost).toBe("example.com:1234");
+  expect(forwardedHeaders.xForwardedProto).toBe("http");
+  expect(forwardedHeaders.xCustomHeader).toBe("keep-me");
+});
 test("one client can make requests to two different paths on the same backend", async () => {
   await createBackendServer({
     port: 3000,

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -36,12 +36,25 @@ export function boot(opts: ProxyConfig) {
       `Proxy request received - Host: ${hostHeader} - host config found`,
     );
 
+    const forwardedHeaders: http.OutgoingHttpHeaders = {
+      ...proxyRequest.headers,
+    };
+    delete forwardedHeaders["x-forwarded-for"];
+    delete forwardedHeaders["x-forwarded-host"];
+    delete forwardedHeaders["x-forwarded-proto"];
+    delete forwardedHeaders.forwarded;
+
+    forwardedHeaders["x-forwarded-for"] =
+      proxyRequest.socket.remoteAddress ?? "";
+    forwardedHeaders["x-forwarded-host"] = hostHeader;
+    forwardedHeaders["x-forwarded-proto"] = "http";
+
     const backendUrl = new URL(proxyRequest.url ?? "/", backendService);
     const backendRequest = http.request(
       backendUrl,
       {
         method: proxyRequest.method,
-        headers: proxyRequest.headers,
+        headers: forwardedHeaders,
       },
       (backendResponse) => {
         if (backendResponse.statusCode) {

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -42,10 +42,12 @@ export function boot(opts: ProxyConfig) {
     delete forwardedHeaders["x-forwarded-for"];
     delete forwardedHeaders["x-forwarded-host"];
     delete forwardedHeaders["x-forwarded-proto"];
-    delete forwardedHeaders.forwarded;
+    delete forwardedHeaders["forwarded"];
 
-    forwardedHeaders["x-forwarded-for"] =
-      proxyRequest.socket.remoteAddress ?? "";
+    const remoteAddress = proxyRequest.socket.remoteAddress;
+    if (remoteAddress != null) {
+      forwardedHeaders["x-forwarded-for"] = remoteAddress;
+    }
     forwardedHeaders["x-forwarded-host"] = hostHeader;
     forwardedHeaders["x-forwarded-proto"] = "http";
 


### PR DESCRIPTION
### Motivation
- Ensure the proxy is the trusted edge for forwarding headers by dropping any incoming forwarding headers and setting its own authoritative values before sending requests to backends.
- Avoid trusting upstream/attacker-controlled forwarding headers while preserving all other client headers and keeping existing host-based routing behavior unchanged.

### Description
- Clone incoming headers into a new `forwardedHeaders` object (`...proxyRequest.headers`) and avoid mutating the original request headers.
- Remove untrusted forwarding headers: `x-forwarded-for`, `x-forwarded-host`, `x-forwarded-proto`, and `forwarded` before proxying.
- Set edge-controlled forwarding headers on the proxied request: `x-forwarded-for` from `proxyRequest.socket.remoteAddress`, `x-forwarded-host` from the validated `Host` header, and `x-forwarded-proto` to `http`.
- Preserve all other headers and leave routing behavior unchanged.

### Testing
- Added a test `replaces forwarding headers and preserves other headers` that sends fabricated forwarding headers and verifies they are dropped and replaced while other headers are preserved.
- Ran the test suite with `npm test -- --run` in the `proxy/` folder and all tests passed (Test Files: 1 passed, Tests: 7 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62db7cfbc8327b0b5bb1d8ec6996a)