### PR TITLE
Add backend server pools and random load balancing to reverse proxy

### DIFF
--- a/proxy/reverse-proxy-dev-load-balanced.ts
+++ b/proxy/reverse-proxy-dev-load-balanced.ts
@@ -4,7 +4,11 @@ boot({
   port: 8080,
   backends: {
     "example.com": {
-      servers: [{ url: "http://localhost:3000" }],
+      servers: [
+        { url: "http://localhost:3000" },
+        { url: "http://localhost:3001" },
+      ],
+      loadBalancingPolicy: "random",
     },
     "attacker.com": {
       servers: [{ url: "http://localhost:4000" }],

--- a/proxy/reverse-proxy-dev.ts
+++ b/proxy/reverse-proxy-dev.ts
@@ -1,9 +1,14 @@
-import { boot } from "./reverse-proxy.ts";
+import { boot } from "./reverse-proxy.js";
 
 boot({
   port: 8080,
-  backendByHostname: {
-    "example.com": "localhost:3000",
-    "attacker.com": "localhost:4000",
+  backends: {
+    "example.com": {
+      servers: [{ url: "http://localhost:3000" }, { url: "http://localhost:3001" }],
+      policy: "random",
+    },
+    "attacker.com": {
+      servers: [{ url: "http://localhost:4000" }],
+    },
   },
 });

--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -80,6 +80,59 @@ test("proxies requests when the Host header includes the port", async () => {
   expect(exampleDotComWithPortResponse.body).toBe("service on 3000");
 });
 
+test("returns 400 when the Host header is missing", async () => {
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    // Stop Node setting a Host header for this test.
+    setHost: false,
+  });
+
+  expect(response.statusCode).toBe(400);
+  expect(response.body).toBe("");
+});
+
+test("returns 400 when the Host header is malformed", async () => {
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "exa mple.com",
+    },
+  });
+
+  expect(response.statusCode).toBe(400);
+  expect(response.body).toBe("Bad Request");
+});
+
+test("returns 502 when the Host header does not match a configured backend", async () => {
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "unknown.example",
+    },
+  });
+
+  expect(response.statusCode).toBe(502);
+  expect(response.body).toBe("Bad Gateway");
+});
+
 test("returns 502 when the proxy cannot connect to the backend", async () => {
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
@@ -286,7 +339,7 @@ test("supports random load balancing policy", async () => {
             { url: "http://localhost:3000" },
             { url: "http://localhost:4000" },
           ],
-          policy: "random",
+          loadBalancingPolicy: "random",
         },
       },
     });
@@ -364,11 +417,13 @@ async function createProxyServer(config: ProxyConfig) {
       headers = {},
       body,
       path = "/",
+      setHost = true,
     }: {
       method?: string;
       headers?: http.OutgoingHttpHeaders;
       body?: string;
       path?: string;
+      setHost?: boolean;
     }) =>
       makeRequest({
         body,
@@ -376,6 +431,7 @@ async function createProxyServer(config: ProxyConfig) {
         method,
         path,
         port: proxyAddress.port,
+        setHost,
       }),
   };
 }
@@ -414,12 +470,14 @@ function makeRequest({
   method = "GET",
   path = "/",
   port,
+  setHost = true,
 }: {
   body?: string;
   headers?: http.OutgoingHttpHeaders;
   method?: string;
   path?: string;
   port: number;
+  setHost?: boolean;
 }) {
   return new Promise<{
     body: string;
@@ -434,6 +492,7 @@ function makeRequest({
         port,
         path,
         headers,
+        setHost,
       },
       (response) => {
         let body = "";

--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -1,6 +1,6 @@
 import * as http from "node:http";
 
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 
 import { boot, ProxyConfig } from "./reverse-proxy.js";
 
@@ -31,9 +31,9 @@ test("proxies requests to the backend matched by host", async () => {
 
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
-      "example.com": "http://localhost:3000",
-      "example.test": "http://localhost:4000",
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+      "example.test": { servers: [{ url: "http://localhost:4000" }] },
     },
   });
 
@@ -66,8 +66,8 @@ test("proxies requests when the Host header includes the port", async () => {
 
   const { proxyPort, makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
-      "example.com": "http://localhost:3000",
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
   });
 
@@ -83,9 +83,9 @@ test("proxies requests when the Host header includes the port", async () => {
 test("returns 502 when the proxy cannot connect to the backend", async () => {
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
+    backends: {
       // Assume nothing is listening on this high-numbered port.
-      "example.com": `http://localhost:54321`,
+      "example.com": { servers: [{ url: `http://localhost:54321` }] },
     },
   });
 
@@ -107,8 +107,8 @@ test("passes through a 500 response from the backend", async () => {
 
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
-      "example.com": "http://localhost:3000",
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
   });
 
@@ -146,8 +146,8 @@ test("client method, headers and body are sent to backend", async () => {
 
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
-      "example.com": "http://localhost:3000",
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
   });
 
@@ -184,8 +184,8 @@ test("replaces forwarding headers and preserves other headers", async () => {
 
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
-      "example.com": "http://localhost:3000",
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
   });
 
@@ -226,8 +226,8 @@ test("one client can make requests to two different paths on the same backend", 
 
   const { makeProxyRequest } = await createProxyServer({
     port: 0,
-    backendByHostname: {
-      "example.com": "http://localhost:3000",
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
   });
 
@@ -250,6 +250,67 @@ test("one client can make requests to two different paths on the same backend", 
   expect(secondResponse.body).toBe("backend saw path /second-path");
 });
 
+test("returns 502 when a backend has no servers", async () => {
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "example.com",
+    },
+  });
+
+  expect(response.statusCode).toBe(502);
+  expect(response.body).toBe("Bad Gateway");
+});
+
+test("supports random load balancing policy", async () => {
+  await createBackendServer({ port: 3000, body: "service on 3000" });
+  await createBackendServer({ port: 4000, body: "service on 4000" });
+
+  const randomSpy = vi
+    .spyOn(Math, "random")
+    .mockReturnValueOnce(0.01)
+    .mockReturnValueOnce(0.99);
+
+  try {
+    const { makeProxyRequest } = await createProxyServer({
+      port: 0,
+      backends: {
+        "example.com": {
+          servers: [
+            { url: "http://localhost:3000" },
+            { url: "http://localhost:4000" },
+          ],
+          policy: "random",
+        },
+      },
+    });
+
+    const firstResponse = await makeProxyRequest({
+      headers: {
+        Host: "example.com",
+      },
+    });
+    expect(firstResponse.statusCode).toBe(200);
+    expect(firstResponse.body).toBe("service on 3000");
+
+    const secondResponse = await makeProxyRequest({
+      headers: {
+        Host: "example.com",
+      },
+    });
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.body).toBe("service on 4000");
+  } finally {
+    randomSpy.mockRestore();
+  }
+});
+
 async function createBackendServer({
   port,
   body,
@@ -258,7 +319,7 @@ async function createBackendServer({
   handleRequest,
 }: {
   port: number;
-  body: string;
+  body?: string;
   statusCode?: number;
   headers?: http.OutgoingHttpHeaders;
   handleRequest?: (
@@ -276,7 +337,7 @@ async function createBackendServer({
     for (const [headerName, headerValue] of Object.entries(headers)) {
       response.setHeader(headerName, headerValue ?? "");
     }
-    response.end(body);
+    response.end(body ?? "");
   });
 
   backendServers.push(server);

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -9,13 +9,18 @@ import * as http from "node:http";
 
 export type ProxyConfig = {
   port?: number;
-  /** Mapping of hostname to backend which should be sent those requests. */
+  /** Different backends this proxy can send requests to. Key is the hostname that should be proxied. */
   backends: Record<string, BackendConfig>;
 };
 
 export type BackendConfig = {
+  /** Servers that will receive requests for this backend. */
   servers: ServerConfig[];
-  policy?: "random";
+  /**
+   * Policy to use when load balancing between multiple servers.
+   * - random: Choose a random server.
+   */
+  loadBalancingPolicy?: "random";
 };
 
 export type ServerConfig = {
@@ -31,21 +36,20 @@ export function boot(opts: ProxyConfig) {
     const hostname =
       hostHeader == null ? null : getHostnameFromHostHeader(hostHeader);
 
-    // Reject request if host is not in our proxy config.
-    const backendConfig = hostname == null ? null : backends[hostname];
-    if (backendConfig == null) {
-      console.log(`Proxy request received - Host: ${hostHeader} - not found`);
-      proxyResponse.statusCode = 502;
-      proxyResponse.end("Bad Gateway");
+    if (hostHeader == null || hostname == null) {
+      console.error(
+        `Proxy request received - Host: ${hostHeader} - invalid host`,
+      );
+      proxyResponse.statusCode = 400;
+      proxyResponse.end("Bad Request");
       return;
     }
 
-    // We have a valid backend. Proxy the incoming request to the backend service.
-    const selectedServer = selectServer(backendConfig);
+    const selectedServer = selectServer({
+      backends,
+      hostname,
+    });
     if (selectedServer == null) {
-      console.log(
-        `Proxy request received - Host: ${hostHeader} - no servers configured`,
-      );
       proxyResponse.statusCode = 502;
       proxyResponse.end("Bad Gateway");
       return;
@@ -117,13 +121,32 @@ function getHostnameFromHostHeader(hostHeader: string) {
   }
 }
 
-function selectServer(backendConfig: BackendConfig) {
-  if (backendConfig.servers.length === 0) {
+function selectServer({
+  backends,
+  hostname,
+}: {
+  backends: Record<string, BackendConfig>;
+  hostname: string;
+}) {
+  const backendConfig = backends[hostname];
+  if (backendConfig == null) {
+    console.error(
+      `Proxy request received - hostname: ${hostname} - no backend configured`,
+    );
     return null;
   }
 
-  if (backendConfig.policy === "random") {
-    const serverIndex = Math.floor(Math.random() * backendConfig.servers.length);
+  if (backendConfig.servers.length === 0) {
+    console.error(
+      `Proxy request received - hostname: ${hostname} - no servers configured`,
+    );
+    return null;
+  }
+
+  if (backendConfig.loadBalancingPolicy === "random") {
+    const serverIndex = Math.floor(
+      Math.random() * backendConfig.servers.length,
+    );
     return backendConfig.servers[serverIndex] ?? null;
   }
 

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -10,12 +10,21 @@ import * as http from "node:http";
 export type ProxyConfig = {
   port?: number;
   /** Mapping of hostname to backend which should be sent those requests. */
-  backendByHostname: Record<string, string>;
+  backends: Record<string, BackendConfig>;
+};
+
+export type BackendConfig = {
+  servers: ServerConfig[];
+  policy?: "random";
+};
+
+export type ServerConfig = {
+  url: string;
 };
 
 export function boot(opts: ProxyConfig) {
   const port = opts.port ?? process.env.PROXY_PORT ?? 8080;
-  const { backendByHostname } = opts;
+  const { backends } = opts;
 
   const server = createServer((proxyRequest, proxyResponse) => {
     const hostHeader = proxyRequest.headers.host;
@@ -23,7 +32,8 @@ export function boot(opts: ProxyConfig) {
       hostHeader == null ? null : getHostnameFromHostHeader(hostHeader);
 
     // Reject request if host is not in our proxy config.
-    if (hostname == null || backendByHostname[hostname] == null) {
+    const backendConfig = hostname == null ? null : backends[hostname];
+    if (backendConfig == null) {
       console.log(`Proxy request received - Host: ${hostHeader} - not found`);
       proxyResponse.statusCode = 502;
       proxyResponse.end("Bad Gateway");
@@ -31,7 +41,17 @@ export function boot(opts: ProxyConfig) {
     }
 
     // We have a valid backend. Proxy the incoming request to the backend service.
-    const backendService = backendByHostname[hostname];
+    const selectedServer = selectServer(backendConfig);
+    if (selectedServer == null) {
+      console.log(
+        `Proxy request received - Host: ${hostHeader} - no servers configured`,
+      );
+      proxyResponse.statusCode = 502;
+      proxyResponse.end("Bad Gateway");
+      return;
+    }
+
+    const backendService = selectedServer.url;
     console.log(
       `Proxy request received - Host: ${hostHeader} - host config found`,
     );
@@ -95,4 +115,17 @@ function getHostnameFromHostHeader(hostHeader: string) {
   } catch {
     return null;
   }
+}
+
+function selectServer(backendConfig: BackendConfig) {
+  if (backendConfig.servers.length === 0) {
+    return null;
+  }
+
+  if (backendConfig.policy === "random") {
+    const serverIndex = Math.floor(Math.random() * backendConfig.servers.length);
+    return backendConfig.servers[serverIndex] ?? null;
+  }
+
+  return backendConfig.servers[0] ?? null;
 }

--- a/proxy/tsconfig.json
+++ b/proxy/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "module": "nodenext",
     "target": "es2022",
     "strict": true


### PR DESCRIPTION
### Motivation
- Replace the single-backend mapping with a backend pool model so a hostname can route to multiple servers. 
- Allow simple load balancing policies (starting with `policy: "random"`) to distribute requests across backend servers. 
- Return a clear `502 Bad Gateway` when a backend is configured but has no servers available.

### Description
- Change the proxy config shape to `backends: Record<string, BackendConfig>` and add `BackendConfig` and `ServerConfig` types in `proxy/reverse-proxy.ts` so each backend can list multiple `servers` and an optional `policy`.
- Implement `selectServer(backendConfig)` which picks the first server by default or a random server when `policy` is `"random"`, and wire it into the request flow so each proxy request targets the selected server URL.
- Update request handling to return `502` when a hostname is not configured or when a backend exists but has an empty `servers` list.
- Update `proxy/reverse-proxy-dev.ts` to demonstrate a multi-server backend with `policy: "random"` and update `proxy/reverse-proxy.test.ts` to use the new `backends` shape, add tests for empty-server handling, and add a deterministic test for the random policy using `vi.spyOn(Math, "random")`; also adjust test helpers (optional `body` and `.js` imports) for TypeScript compatibility.

### Testing
- Ran `npm test` in `proxy/` and all tests passed (1 test file, 9 tests total passed). 
- Ran `npm run types` (TypeScript `tsc --noEmit`) in `proxy/` and type checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6376e81d883279d621d593d79e82e)