### PR TITLE
Add backend request timeout handling to reverse proxy and tests

### DIFF
--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -151,6 +151,60 @@ test("returns 502 when the proxy cannot connect to the backend", async () => {
   expect(response.body).toBe("Bad Gateway");
 });
 
+
+test("uses 30s backend timeout by default", async () => {
+  await createBackendServer({ port: 3000, body: "service on 3000" });
+
+  const timeoutSpy = vi.spyOn(http.ClientRequest.prototype, "setTimeout");
+
+  try {
+    const { makeProxyRequest } = await createProxyServer({
+      port: 0,
+      backends: {
+        "example.com": { servers: [{ url: "http://localhost:3000" }] },
+      },
+    });
+
+    const response = await makeProxyRequest({
+      headers: {
+        Host: "example.com",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000, expect.any(Function));
+  } finally {
+    timeoutSpy.mockRestore();
+  }
+});
+test("returns 504 when backend response exceeds configured timeout", async () => {
+  await createBackendServer({
+    port: 3000,
+    handleRequest: async (_request, response) => {
+      await delay(100);
+      response.statusCode = 200;
+      response.end("slow backend response");
+    },
+  });
+
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backendRequestTimeoutMs: 10,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "example.com",
+    },
+  });
+
+  expect(response.statusCode).toBe(504);
+  expect(response.body).toBe("Gateway Timeout");
+});
+
 test("passes through a 500 response from the backend", async () => {
   await createBackendServer({
     port: 3000,
@@ -461,6 +515,13 @@ function closeServer(server: http.Server) {
 
       resolve();
     });
+  });
+}
+
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
   });
 }
 

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -87,16 +87,16 @@ export function boot(opts: ProxyConfig) {
     forwardedHeaders["x-forwarded-host"] = hostHeader;
     forwardedHeaders["x-forwarded-proto"] = "http";
 
-    const backendUrl = new URL(proxyRequest.url ?? "/", backendService);
-    // Prevent multiple writes when timeout, error, and response events race.
+    const backendUrl = new URL(proxyRequest.url ?? "/", backendService)
+    // Flag to prevent any race conditions on callbacks trying to respond twice.
     let responseSent = false;
 
     const sendGatewayError = (statusCode: number, message: string) => {
-      if (responseSent || proxyResponse.headersSent || proxyResponse.writableEnded) {
+      if (responseSent) {
         return;
       }
-
       responseSent = true;
+
       proxyResponse.statusCode = statusCode;
       proxyResponse.end(message);
     };
@@ -108,8 +108,12 @@ export function boot(opts: ProxyConfig) {
         headers: forwardedHeaders,
       },
       (backendResponse) => {
+        if (responseSent) {
+          return;
+        }
+        responseSent = true;
+
         if (backendResponse.statusCode) {
-          responseSent = true;
           proxyResponse.writeHead(
             backendResponse.statusCode,
             backendResponse.headers,
@@ -121,9 +125,9 @@ export function boot(opts: ProxyConfig) {
       },
     );
 
-    // Timeout the request.
+    // Timeout the proxy request
     backendRequest.setTimeout(backendRequestTimeoutMs, () => {
-      // Destroy closes the underlying TCP connection and releases the socket.
+      // This will close the TCP connection and release the socket.
       backendRequest.destroy(new Error("Backend request timed out"));
       sendGatewayError(504, "Gateway Timeout");
     });

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -10,7 +10,9 @@ import * as http from "node:http";
 export type ProxyConfig = {
   port?: number;
   /**
-   * Timeout in milliseconds for requests to backend servers.
+   * Idle timeout in milliseconds for requests to backend servers.
+   * This currently covers inactivity on the proxied backend request.
+   * In future, this could be split into separate connect, first-byte, and idle timeouts.
    * When exceeded, the proxy returns 504 Gateway Timeout.
    * Defaults to 30 seconds.
    */

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -88,6 +88,7 @@ export function boot(opts: ProxyConfig) {
     forwardedHeaders["x-forwarded-proto"] = "http";
 
     const backendUrl = new URL(proxyRequest.url ?? "/", backendService);
+    // Prevent multiple writes when timeout, error, and response events race.
     let responseSent = false;
 
     const sendGatewayError = (statusCode: number, message: string) => {

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -9,6 +9,12 @@ import * as http from "node:http";
 
 export type ProxyConfig = {
   port?: number;
+  /**
+   * Timeout in milliseconds for requests to backend servers.
+   * When exceeded, the proxy returns 504 Gateway Timeout.
+   * Defaults to 30 seconds.
+   */
+  backendRequestTimeoutMs?: number;
   /** Different backends this proxy can send requests to. Key is the hostname that should be proxied. */
   backends: Record<string, BackendConfig>;
 };
@@ -27,9 +33,13 @@ export type ServerConfig = {
   url: string;
 };
 
+const DEFAULT_BACKEND_REQUEST_TIMEOUT_MS = 30_000;
+
 export function boot(opts: ProxyConfig) {
   const port = opts.port ?? process.env.PROXY_PORT ?? 8080;
   const { backends } = opts;
+  const backendRequestTimeoutMs =
+    opts.backendRequestTimeoutMs ?? DEFAULT_BACKEND_REQUEST_TIMEOUT_MS;
 
   const server = createServer((proxyRequest, proxyResponse) => {
     const hostHeader = proxyRequest.headers.host;
@@ -76,6 +86,18 @@ export function boot(opts: ProxyConfig) {
     forwardedHeaders["x-forwarded-proto"] = "http";
 
     const backendUrl = new URL(proxyRequest.url ?? "/", backendService);
+    let responseSent = false;
+
+    const sendGatewayError = (statusCode: number, message: string) => {
+      if (responseSent || proxyResponse.headersSent || proxyResponse.writableEnded) {
+        return;
+      }
+
+      responseSent = true;
+      proxyResponse.statusCode = statusCode;
+      proxyResponse.end(message);
+    };
+
     const backendRequest = http.request(
       backendUrl,
       {
@@ -84,23 +106,27 @@ export function boot(opts: ProxyConfig) {
       },
       (backendResponse) => {
         if (backendResponse.statusCode) {
+          responseSent = true;
           proxyResponse.writeHead(
             backendResponse.statusCode,
             backendResponse.headers,
           );
           backendResponse.pipe(proxyResponse);
         } else {
-          proxyResponse.statusCode = 502;
-          proxyResponse.end("Bad Gateway");
+          sendGatewayError(502, "Bad Gateway");
         }
       },
     );
 
+    backendRequest.setTimeout(backendRequestTimeoutMs, () => {
+      backendRequest.destroy(new Error("Backend request timed out"));
+      sendGatewayError(504, "Gateway Timeout");
+    });
+
     // Handle error.
     backendRequest.on("error", (error) => {
       console.error(error);
-      proxyResponse.statusCode = 502;
-      proxyResponse.end("Bad Gateway");
+      sendGatewayError(502, "Bad Gateway");
     });
 
     proxyRequest.pipe(backendRequest);

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -120,7 +120,9 @@ export function boot(opts: ProxyConfig) {
       },
     );
 
+    // Timeout the request.
     backendRequest.setTimeout(backendRequestTimeoutMs, () => {
+      // Destroy closes the underlying TCP connection and releases the socket.
       backendRequest.destroy(new Error("Backend request timed out"));
       sendGatewayError(504, "Gateway Timeout");
     });


### PR DESCRIPTION
### Motivation

- Ensure backend requests do not hang indefinitely by introducing a configurable timeout for requests to backend servers. 

### Description

- Add `backendRequestTimeoutMs` to `ProxyConfig` with a `DEFAULT_BACKEND_REQUEST_TIMEOUT_MS` of `30000` and use it when creating backend requests. 
- Call `backendRequest.setTimeout(...)` to enforce the timeout and destroy the backend request on timeout while returning `504 Gateway Timeout`. 
- Introduce a `responseSent` flag and `sendGatewayError` helper to avoid sending multiple responses, and switch backend error handling to use this helper. 
- Add tests and helpers: a `delay` helper and two tests verifying the default 30s timeout is applied (`uses 30s backend timeout by default`) and that a configured short timeout yields `504` for slow backends (`returns 504 when backend response exceeds configured timeout`).

### Testing

- Ran the unit tests in `proxy/reverse-proxy.test.ts`, including the new timeout tests `uses 30s backend timeout by default` and `returns 504 when backend response exceeds configured timeout`. 
- All tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ece9a6148327b3a7dfef7f45c498)