### PR TITLE
Reject absolute-form request targets to prevent backend override attacks

### DIFF
--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -418,6 +418,86 @@ test("supports random load balancing policy", async () => {
   }
 });
 
+test("rejects absolute-form URL request targets to prevent backend override attacks", async () => {
+  await createBackendServer({
+    port: 3000,
+    body: "trusted backend",
+  });
+  await createBackendServer({
+    port: 4000,
+    body: "attacker backend",
+  });
+
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "example.com",
+    },
+    path: "http://127.0.0.1:4000/steal-data",
+  });
+
+  expect(response.statusCode).toBe(400);
+  expect(response.body).toBe("Bad Request");
+});
+
+test("rejects same-host absolute-form URL request targets", async () => {
+  await createBackendServer({
+    port: 3000,
+    body: "trusted backend",
+  });
+
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "example.com",
+    },
+    path: "http://example.com/steal-data",
+  });
+
+  expect(response.statusCode).toBe(400);
+  expect(response.body).toBe("Bad Request");
+});
+
+test("rejects network-path URL request targets to prevent backend override attacks", async () => {
+  await createBackendServer({
+    port: 3000,
+    body: "trusted backend",
+  });
+  await createBackendServer({
+    port: 4000,
+    body: "attacker backend",
+  });
+
+  const { makeProxyRequest } = await createProxyServer({
+    port: 0,
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeProxyRequest({
+    headers: {
+      Host: "example.com",
+    },
+    path: "//127.0.0.1:4000/steal-data",
+  });
+
+  expect(response.statusCode).toBe(400);
+  expect(response.body).toBe("Bad Request");
+});
+
 async function createBackendServer({
   port,
   body,

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -67,7 +67,6 @@ export function boot(opts: ProxyConfig) {
       return;
     }
 
-    const backendService = selectedServer.url;
     console.log(
       `Proxy request received - Host: ${hostHeader} - host config found`,
     );
@@ -87,7 +86,6 @@ export function boot(opts: ProxyConfig) {
     forwardedHeaders["x-forwarded-host"] = hostHeader;
     forwardedHeaders["x-forwarded-proto"] = "http";
 
-    const backendUrl = new URL(proxyRequest.url ?? "/", backendService)
     // Flag to prevent any race conditions on callbacks trying to respond twice.
     let responseSent = false;
 
@@ -101,10 +99,23 @@ export function boot(opts: ProxyConfig) {
       proxyResponse.end(message);
     };
 
+    const serverDetails = getServerDetails({
+      selectedServer,
+      requestTarget: proxyRequest.url,
+    });
+    if (serverDetails == null) {
+      sendGatewayError(400, "Bad Request");
+      return;
+    }
+
+    // Make request to backend.
     const backendRequest = http.request(
-      backendUrl,
       {
         method: proxyRequest.method,
+        protocol: serverDetails.protocol,
+        hostname: serverDetails.hostname,
+        port: serverDetails.port,
+        path: serverDetails.path,
         headers: forwardedHeaders,
       },
       (backendResponse) => {
@@ -186,4 +197,37 @@ function selectServer({
   }
 
   return backendConfig.servers[0] ?? null;
+}
+
+/**
+ * Get the final server details to use for the call.
+ *
+ * Ensures absolute URLs can't sneakily change the target host.
+ */
+function getServerDetails({
+  selectedServer,
+  requestTarget,
+}: {
+  selectedServer: ServerConfig;
+  requestTarget: string | undefined;
+}) {
+  const normalizedRequestTarget = requestTarget ?? "/";
+  if (
+    !normalizedRequestTarget.startsWith("/") ||
+    normalizedRequestTarget.startsWith("//")
+  ) {
+    console.error(
+      `Proxy request received - rejected non-origin-form request target: ${normalizedRequestTarget}`,
+    );
+    return null;
+  }
+
+  const serverUrl = new URL(selectedServer.url);
+
+  return {
+    protocol: "http:",
+    hostname: serverUrl.hostname,
+    port: serverUrl.port,
+    path: normalizedRequestTarget,
+  };
 }


### PR DESCRIPTION
Prevent backend override attacks where a client supplies an absolute-form request-target to force the proxy to forward to an arbitrary backend.