### PR TITLE
Run CI checks for proxy instead of cors

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-name: CORS
+name: Proxy
 
 on: push
 
@@ -8,16 +8,17 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [24.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{matrix.node-version}}
-    - run: npm ci
-      working-directory: ./cors
-    # seems to timeout at the moment so disabling
-    # - run: npm test
-    #   working-directory: ./cors
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./proxy
+      - run: npm run types
+        working-directory: ./proxy
+      - run: npm test
+        working-directory: ./proxy


### PR DESCRIPTION
### Motivation
- Replace the existing CORS-oriented workflow which was disabled/timeout-prone with CI that validates the `proxy` package since `proxy` includes type checks and tests.
- Align the workflow Node.js version with `proxy` package `engines` which require Node 24.

### Description
- Rename the workflow to `Proxy` and update the Node.js matrix to `24.x` in `.github/workflows/node.js.yml`.
- Change all `working-directory` usages from `./cors` to `./proxy` and run `npm ci` in `./proxy`.
- Add `- run: npm run types` (running `tsc --noEmit`) in `./proxy` to validate types.
- Add `- run: npm test` in `./proxy` to execute the package tests.

### Testing
- Verified the updated workflow file with `nl -ba .github/workflows/node.js.yml`, which displayed the new steps and Node version, and it succeeded.
- Confirmed repository status with `git status --short` and recorded the commit via `git show --stat --oneline`, both of which succeeded.
- Note: the GitHub Actions workflow itself has not been executed locally and will run on push.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ec7145a48327b99064fdff9c9eba)