### PR TITLE
Add macOS installer script to import generated root CA into login.keychain

### DIFF
--- a/https/openssl-node-https-certs-demo/install-root-ca-cert.ts
+++ b/https/openssl-node-https-certs-demo/install-root-ca-cert.ts
@@ -1,0 +1,62 @@
+import { existsSync } from "node:fs";
+import { execFile as execFileCallback } from "node:child_process";
+import { homedir, platform } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+const buildDirPath = resolve(process.cwd(), "build");
+const rootCaCertPath = join(buildDirPath, "certificate-authority", "ca-root.crt");
+const loginKeychainPath = join(
+  homedir(),
+  "Library",
+  "Keychains",
+  "login.keychain-db",
+);
+
+async function main() {
+  assertRootCaCertExists(rootCaCertPath);
+
+  if (platform() !== "darwin") {
+    console.warn(
+      `Skipping macOS keychain installation because platform is ${platform()}.`,
+    );
+    return;
+  }
+
+  console.log(`Installing root CA certificate into keychain: ${loginKeychainPath}`);
+  await execFile("security", [
+    "add-trusted-cert",
+    // -d stores trust settings in the admin domain.
+    "-d",
+    // -r trustRoot marks the cert as a trusted root certificate.
+    "-r",
+    "trustRoot",
+    // -k chooses the keychain file where the cert will be installed.
+    "-k",
+    loginKeychainPath,
+    // Final positional argument is the certificate file to import.
+    rootCaCertPath,
+  ]);
+
+  console.log("Root CA certificate installed successfully.");
+}
+
+function assertRootCaCertExists(certPath: string) {
+  if (existsSync(certPath)) {
+    console.log(`Found root CA certificate: ${certPath}`);
+    return;
+  }
+
+  throw new Error(
+    `Root CA certificate not found at ${certPath}. Run generate-certificate-test.ts first to create build output.`,
+  );
+}
+
+main().catch(handleFatalError);
+
+function handleFatalError(error: unknown) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/https/openssl-node-https-certs-demo/package.json
+++ b/https/openssl-node-https-certs-demo/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "scripts": {
-    "start": "node generate-certificate-test.ts"
+    "start": "node generate-certificate-test.ts",
+    "install-root-ca-cert": "node install-root-ca-cert.ts"
   }
 }

--- a/https/openssl-node-https-certs-demo/tsconfig.json
+++ b/https/openssl-node-https-certs-demo/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "include": [
     "generate-certificate-test.ts",
+    "install-root-ca-cert.ts",
     "../openssl-node/openssl-node.ts"
   ]
 }


### PR DESCRIPTION
### Motivation
- Provide a convenient way to install the generated root CA into the macOS login keychain so locally-issued certs are trusted by the system.
- Make the installer invokable via npm script to simplify developer workflow when using the demo certificate generator.

### Description
- Add `install-root-ca-cert.ts` which verifies `build/certificate-authority/ca-root.crt`, checks for `darwin` platform, and runs `security add-trusted-cert -d -r trustRoot -k <login.keychain>` to import the certificate.
- Add an npm script `install-root-ca-cert` to `package.json` that runs `node install-root-ca-cert.ts`.
- Update `tsconfig.json` include list to add `install-root-ca-cert.ts` so it is included in builds/type checks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca245b024c8327b22a8a9555e8a393)