### PR TITLE
Add more Node HTTPS tests around SAN variations

### DIFF
--- a/https/certgen/.gitignore
+++ b/https/certgen/.gitignore
@@ -1,2 +1,4 @@
 build-ca
 build-issued-cert
+build-test-ca
+build-test-issued-cert

--- a/https/certgen/README.md
+++ b/https/certgen/README.md
@@ -36,6 +36,8 @@ certificate valid for `localhost`.
 
 When using `issueCertificate(...)` programmatically, the SAN extension is derived from `dnsNames` and
 `ipAddresses`. If both arrays are empty, the certificate is issued without SAN entries.
+`commonName` is configurable; by default it uses the first DNS SAN, otherwise the first IP SAN,
+otherwise `common-name-default`.
 
 Output directory `build-issued-cert` containing:
 - `private-key.key`: The private key for the issued certificate.

--- a/https/certgen/README.md
+++ b/https/certgen/README.md
@@ -31,7 +31,11 @@ This script will remove the generated CA certificate from the system trust store
 `npm run issue-cert`
 
 This script issues a TLS certificate from a CSR using the CA we generated. You can run this multiple times, to 
-generate new certificates, each signed by the same generated certificate authority.
+generate new certificates, each signed by the same generated certificate authority. The CLI defaults to a
+certificate valid for `localhost`.
+
+When using `issueCertificate(...)` programmatically, the SAN extension is derived from `dnsNames` and
+`ipAddresses`. If both arrays are empty, the certificate is issued without SAN entries.
 
 Output directory `build-issued-cert` containing:
 - `private-key.key`: The private key for the issued certificate.

--- a/https/certgen/TODO.md
+++ b/https/certgen/TODO.md
@@ -1,2 +1,3 @@
 - Generate certificate that can be used for mTLS
 - Support trust store for Windows
+- Allow passing of domains and IPs as an argument to the CLI issue certificate command.

--- a/https/certgen/certgen.test.ts
+++ b/https/certgen/certgen.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { rm, stat } from "node:fs/promises";
+import test from "node:test";
+import { generateCa } from "./generate-ca.ts";
+import { issueCertificate, verifyCertificate } from "./issue-cert.ts";
+
+test("generate-ca output can be used by issue-cert and verified explicitly", async () => {
+  try {
+    // Generate certificate authority artifacts.
+    const { caPrivateKeyPath, caRootCertPath } = await generateCa({
+      outputDirectoryPath: "build-test-ca",
+    });
+
+    await assertPathMatchesAndFileExists(
+      caPrivateKeyPath,
+      "build-test-ca/ca-private-key.key",
+    );
+    await assertPathMatchesAndFileExists(
+      caRootCertPath,
+      "build-test-ca/ca-root.crt",
+    );
+
+    // Issue a certificate signed by the certificate authority.
+    const issuedCertificate = await issueCertificate({
+      outputDirectoryPath: "build-test-issued-cert",
+      caDirectoryPath: "build-test-ca",
+      dnsNames: ["localhost"],
+      verifyCertificateAfterCreation: false,
+    });
+
+    await assertPathMatchesAndFileExists(
+      issuedCertificate.privateKeyPath,
+      "build-test-issued-cert/private-key.key",
+    );
+    await assertPathMatchesAndFileExists(
+      issuedCertificate.certCsrPath,
+      "build-test-issued-cert/cert.csr",
+    );
+    await assertPathMatchesAndFileExists(
+      issuedCertificate.certPath,
+      "build-test-issued-cert/cert.crt",
+    );
+    assert.equal(
+      issuedCertificate.caPrivateKeyPath,
+      "build-test-ca/ca-private-key.key",
+    );
+    assert.equal(issuedCertificate.caRootCertPath, "build-test-ca/ca-root.crt");
+
+    await assertFileExistsWithContent("build-test-issued-cert/cert-v3.ext");
+
+    // Verify the issues certificate is signed by the CA.
+    const verificationResult = await verifyCertificate(
+      "build-test-ca/ca-root.crt",
+      issuedCertificate.certPath,
+    );
+    assert.equal(
+      verificationResult.stdout.trim(),
+      `${issuedCertificate.certPath}: OK`,
+    );
+  } finally {
+    await rm("build-test-ca", { recursive: true, force: true });
+    await rm("build-test-issued-cert", { recursive: true, force: true });
+    assert.equal(existsSync("build-test-ca"), false);
+    assert.equal(existsSync("build-test-issued-cert"), false);
+  }
+});
+
+async function assertPathMatchesAndFileExists(
+  actualPath: string,
+  expectedPath: string,
+) {
+  assert.equal(actualPath, expectedPath);
+  await assertFileExistsWithContent(actualPath);
+}
+
+async function assertFileExistsWithContent(filePath: string) {
+  const fileStats = await stat(filePath);
+  assert.equal(fileStats.isFile(), true);
+  assert.ok(fileStats.size > 0);
+}

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -22,6 +22,7 @@ type IssueCertificateOptions = {
   outputDirectoryPath?: string;
   caDirectoryPath?: string;
   dnsNames?: string[];
+  includeSubjectAltName?: boolean;
   certificateDays?: number;
   verifyCertificateAfterCreation?: boolean;
 };
@@ -46,6 +47,7 @@ export async function issueCertificate({
   outputDirectoryPath = getDefaultBuildIssuedCertPath(),
   caDirectoryPath = getDefaultBuildCaPath(),
   dnsNames = ["localhost"],
+  includeSubjectAltName = true,
   certificateDays = 5,
   verifyCertificateAfterCreation = true,
 }: IssueCertificateOptions = {}): Promise<IssueCertificateResult> {
@@ -76,6 +78,7 @@ export async function issueCertificate({
   const certPath = await issueCertificateFromCsr(
     outputDirectoryPath,
     dnsNames,
+    includeSubjectAltName,
     certificateDays,
     caRootCertPath,
     caPrivateKeyPath,
@@ -141,40 +144,54 @@ async function generateCertificateSigningRequest(
 async function issueCertificateFromCsr(
   outputDirectoryPath: string,
   dnsNames: string[],
+  includeSubjectAltName: boolean,
   certificateDays: number,
   caRootCertPath: string,
   caPrivateKeyPath: string,
   certCsrPath: string,
 ) {
-  const certExtensionsPath = await writeCertificateExtensionsFile(
-    outputDirectoryPath,
-    dnsNames,
-  );
+  const certExtensionsPath = includeSubjectAltName
+    ? await writeCertificateExtensionsFile(outputDirectoryPath, dnsNames)
+    : undefined;
   const certPath = getIssuedCertPath(outputDirectoryPath);
   console.log("");
   console.log("CA creating signed certificate from CSR...");
-  // openssl x509 - certificate display and signing command
-  await openssl("x509", [
-    "-req",
-    "-in",
-    certCsrPath,
-    "-CA",
-    caRootCertPath,
-    "-CAkey",
-    caPrivateKeyPath,
-    // OpenSSL option to store a bookkeeping file that stores the next serial number used when this CA
-    // issues certificates
-    "-CAcreateserial",
-    "-out",
-    certPath,
-    // The certificate is valid for the requested number of days.
-    "-days",
-    String(certificateDays),
-    "-sha256",
+  if (certExtensionsPath) {
     // -extfile is required to assign Subject Alternative Name which Chrome requires to trust an SSL certificate.
-    "-extfile",
-    certExtensionsPath,
-  ]);
+    await openssl("x509", [
+      "-req",
+      "-in",
+      certCsrPath,
+      "-CA",
+      caRootCertPath,
+      "-CAkey",
+      caPrivateKeyPath,
+      "-CAcreateserial",
+      "-out",
+      certPath,
+      "-days",
+      String(certificateDays),
+      "-sha256",
+      "-extfile",
+      certExtensionsPath,
+    ]);
+  } else {
+    await openssl("x509", [
+      "-req",
+      "-in",
+      certCsrPath,
+      "-CA",
+      caRootCertPath,
+      "-CAkey",
+      caPrivateKeyPath,
+      "-CAcreateserial",
+      "-out",
+      certPath,
+      "-days",
+      String(certificateDays),
+      "-sha256",
+    ]);
+  }
   console.log(`Created: ${certPath}`);
 
   return certPath;

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -23,6 +23,8 @@ type IssueCertificateOptions = {
   outputDirectoryPath?: string;
   /** Directory containing the certificate authority private key, certificate and other build artifacts. */
   caDirectoryPath?: string;
+  /** Common Name (CN) to write into the certificate subject. */
+  commonName?: string;
   /**
    * DNS names to be written as Subject Alternative Name (SAN) entries.
    * Client will verify that a request matches SAN values.
@@ -55,6 +57,7 @@ type IssueCertificateResult = {
 export async function issueCertificate({
   outputDirectoryPath = getDefaultBuildIssuedCertPath(),
   caDirectoryPath = getDefaultBuildCaPath(),
+  commonName,
   dnsNames = [],
   ipAddresses = [],
   certificateDays = 5,
@@ -76,11 +79,15 @@ export async function issueCertificate({
 
   // Generate private key for this certificate.
   const privateKeyPath = await generatePrivateKey(outputDirectoryPath);
+  // https://cabforum.org/working-groups/server/baseline-requirements/requirements/#7143-subscriber-certificate-common-name-attribute
+  const certificateCommonName =
+    commonName ?? dnsNames[0] ?? ipAddresses[0] ?? "common-name-default";
 
   // Prepare a certificate signing request. This is normally given to a certificate authority.
   const certCsrPath = await generateCertificateSigningRequest(
     outputDirectoryPath,
     privateKeyPath,
+    certificateCommonName,
   );
 
   // Certificate authority creates a signed certificate from the certificate signing request.
@@ -131,6 +138,7 @@ async function generatePrivateKey(outputDirectoryPath: string) {
 async function generateCertificateSigningRequest(
   outputDirectoryPath: string,
   privateKeyPath: string,
+  commonName: string,
 ) {
   const certCsrPath = getIssuedCertCsrPath(outputDirectoryPath);
   console.log("");
@@ -143,7 +151,7 @@ async function generateCertificateSigningRequest(
     "-out",
     certCsrPath,
     "-subj",
-    "/C=UK/ST=London/L=London/O=SSL Test Org/OU=IT/CN=localhost",
+    `/C=UK/ST=London/L=London/O=SSL Test Org/OU=IT/CN=${commonName}`,
   ]);
   console.log(`Created: ${certCsrPath}`);
 

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -15,16 +15,24 @@ import {
 } from "./util/paths.ts";
 
 if (isMainModule()) {
-  issueCertificate().catch(handleFatalError);
+  issueCertificate({ dnsNames: ["localhost"] }).catch(handleFatalError);
 }
 
 type IssueCertificateOptions = {
+  /** Directory to output the private key, certificate and other build artifacts. */
   outputDirectoryPath?: string;
+  /** Directory containing the certificate authority private key, certificate and other build artifacts. */
   caDirectoryPath?: string;
+  /**
+   * DNS names to be written as Subject Alternative Name (SAN) entries.
+   * Client will verify that a request matches SAN values.
+   */
   dnsNames?: string[];
+  /** IP addresses to be written as Subject Alternative Name (SAN) entries. */
   ipAddresses?: string[];
-  includeSubjectAltName?: boolean;
+  /** How many days until the certificate expires. */
   certificateDays?: number;
+  /** Whether to run verification after creation that the certificate is signed by the CA. */
   verifyCertificateAfterCreation?: boolean;
 };
 
@@ -47,9 +55,8 @@ type IssueCertificateResult = {
 export async function issueCertificate({
   outputDirectoryPath = getDefaultBuildIssuedCertPath(),
   caDirectoryPath = getDefaultBuildCaPath(),
-  dnsNames = ["localhost"],
+  dnsNames = [],
   ipAddresses = [],
-  includeSubjectAltName = true,
   certificateDays = 5,
   verifyCertificateAfterCreation = true,
 }: IssueCertificateOptions = {}): Promise<IssueCertificateResult> {
@@ -81,7 +88,6 @@ export async function issueCertificate({
     outputDirectoryPath,
     dnsNames,
     ipAddresses,
-    includeSubjectAltName,
     certificateDays,
     caRootCertPath,
     caPrivateKeyPath,
@@ -148,66 +154,40 @@ async function issueCertificateFromCsr(
   outputDirectoryPath: string,
   dnsNames: string[],
   ipAddresses: string[],
-  includeSubjectAltName: boolean,
   certificateDays: number,
   caRootCertPath: string,
   caPrivateKeyPath: string,
   certCsrPath: string,
 ) {
-  const certExtensionsPath = includeSubjectAltName
-    ? await writeCertificateExtensionsFile(
-        outputDirectoryPath,
-        dnsNames,
-        ipAddresses,
-      )
-    : undefined;
+  const certExtensionsPath = await writeCertificateExtensionsFile(
+    outputDirectoryPath,
+    dnsNames,
+    ipAddresses,
+  );
   const certPath = getIssuedCertPath(outputDirectoryPath);
   console.log("");
   console.log("CA creating signed certificate from CSR...");
-  if (certExtensionsPath) {
-    // -extfile is required to assign Subject Alternative Name which Chrome requires to trust an SSL certificate.
-    await openssl("x509", [
-      // The -req option takes a certificate request and outputs a signed certificate.
-      "-req",
-      "-in",
-      certCsrPath,
-      "-CA",
-      caRootCertPath,
-      "-CAkey",
-      caPrivateKeyPath,
-      // OpenSSL option to store a bookkeeping file that stores the next serial number used when this CA
-      // issues certificates.
-      "-CAcreateserial",
-      "-out",
-      certPath,
-      // The certificate is valid for the requested number of days.
-      "-days",
-      String(certificateDays),
-      "-sha256",
-      "-extfile",
-      certExtensionsPath,
-    ]);
-  } else {
-    await openssl("x509", [
-      // The -req option takes a certificate request and outputs a signed certificate.
-      "-req",
-      "-in",
-      certCsrPath,
-      "-CA",
-      caRootCertPath,
-      "-CAkey",
-      caPrivateKeyPath,
-      // OpenSSL option to store a bookkeeping file that stores the next serial number used when this CA
-      // issues certificates.
-      "-CAcreateserial",
-      "-out",
-      certPath,
-      // The certificate is valid for the requested number of days.
-      "-days",
-      String(certificateDays),
-      "-sha256",
-    ]);
-  }
+  await openssl("x509", [
+    // The -req option takes a certificate request and outputs a signed certificate.
+    "-req",
+    "-in",
+    certCsrPath,
+    "-CA",
+    caRootCertPath,
+    "-CAkey",
+    caPrivateKeyPath,
+    // OpenSSL option to store a bookkeeping file that stores the next serial number used when this CA
+    // issues certificates.
+    "-CAcreateserial",
+    "-out",
+    certPath,
+    // The certificate is valid for the requested number of days.
+    "-days",
+    String(certificateDays),
+    "-sha256",
+    "-extfile",
+    certExtensionsPath,
+  ]);
   console.log(`Created: ${certPath}`);
 
   return certPath;
@@ -229,19 +209,27 @@ async function writeCertificateExtensionsFile(
   const subjectAlternativeNames = [dnsAlternativeNames, ipAlternativeNames]
     .filter(Boolean)
     .join("\n");
+  const hasSubjectAlternativeNames = subjectAlternativeNames.length > 0;
 
-  const extfileContents = [
+  const extfileLines = [
     // Point back to the CA key that signed this certificate.
     "authorityKeyIdentifier=keyid,issuer",
     // Mark this as a leaf certificate, not a CA.
     "basicConstraints=CA:FALSE",
     // Allow normal TLS leaf-certificate key uses.
     "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment",
-    // List the hostname this certificate is valid for.
-    "subjectAltName = @alt_names",
-    "[alt_names]",
-    subjectAlternativeNames,
-  ].join("\n");
+  ];
+
+  if (hasSubjectAlternativeNames) {
+    extfileLines.push(
+      // List the hostnames and IPs this certificate is valid for.
+      "subjectAltName = @alt_names",
+      "[alt_names]",
+      subjectAlternativeNames,
+    );
+  }
+
+  const extfileContents = extfileLines.join("\n");
 
   await writeFile(certExtensionsPath, extfileContents, "utf-8");
   console.log(`Created: ${certExtensionsPath}`);

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -245,16 +245,20 @@ async function writeCertificateExtensionsFile(
   return certExtensionsPath;
 }
 
-async function verifyCertificate(caRootCertPath: string, certPath: string) {
+export async function verifyCertificate(
+  caRootCertPath: string,
+  certPath: string,
+) {
   console.log("");
   console.log("Verifying signed certificate against CA...");
-  await openssl("verify", [
+  const verificationResult = await openssl("verify", [
     "-x509_strict",
     "-CAfile",
     caRootCertPath,
     certPath,
   ]);
   console.log("Verification successful.");
+  return verificationResult;
 }
 
 function assertFileExists(filePath: string, errorMessage: string) {

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -22,6 +22,7 @@ type IssueCertificateOptions = {
   outputDirectoryPath?: string;
   caDirectoryPath?: string;
   dnsNames?: string[];
+  ipAddresses?: string[];
   includeSubjectAltName?: boolean;
   certificateDays?: number;
   verifyCertificateAfterCreation?: boolean;
@@ -47,6 +48,7 @@ export async function issueCertificate({
   outputDirectoryPath = getDefaultBuildIssuedCertPath(),
   caDirectoryPath = getDefaultBuildCaPath(),
   dnsNames = ["localhost"],
+  ipAddresses = [],
   includeSubjectAltName = true,
   certificateDays = 5,
   verifyCertificateAfterCreation = true,
@@ -78,6 +80,7 @@ export async function issueCertificate({
   const certPath = await issueCertificateFromCsr(
     outputDirectoryPath,
     dnsNames,
+    ipAddresses,
     includeSubjectAltName,
     certificateDays,
     caRootCertPath,
@@ -144,6 +147,7 @@ async function generateCertificateSigningRequest(
 async function issueCertificateFromCsr(
   outputDirectoryPath: string,
   dnsNames: string[],
+  ipAddresses: string[],
   includeSubjectAltName: boolean,
   certificateDays: number,
   caRootCertPath: string,
@@ -151,7 +155,11 @@ async function issueCertificateFromCsr(
   certCsrPath: string,
 ) {
   const certExtensionsPath = includeSubjectAltName
-    ? await writeCertificateExtensionsFile(outputDirectoryPath, dnsNames)
+    ? await writeCertificateExtensionsFile(
+        outputDirectoryPath,
+        dnsNames,
+        ipAddresses,
+      )
     : undefined;
   const certPath = getIssuedCertPath(outputDirectoryPath);
   console.log("");
@@ -159,6 +167,7 @@ async function issueCertificateFromCsr(
   if (certExtensionsPath) {
     // -extfile is required to assign Subject Alternative Name which Chrome requires to trust an SSL certificate.
     await openssl("x509", [
+      // The -req option takes a certificate request and outputs a signed certificate.
       "-req",
       "-in",
       certCsrPath,
@@ -166,9 +175,12 @@ async function issueCertificateFromCsr(
       caRootCertPath,
       "-CAkey",
       caPrivateKeyPath,
+      // OpenSSL option to store a bookkeeping file that stores the next serial number used when this CA
+      // issues certificates.
       "-CAcreateserial",
       "-out",
       certPath,
+      // The certificate is valid for the requested number of days.
       "-days",
       String(certificateDays),
       "-sha256",
@@ -177,6 +189,7 @@ async function issueCertificateFromCsr(
     ]);
   } else {
     await openssl("x509", [
+      // The -req option takes a certificate request and outputs a signed certificate.
       "-req",
       "-in",
       certCsrPath,
@@ -184,9 +197,12 @@ async function issueCertificateFromCsr(
       caRootCertPath,
       "-CAkey",
       caPrivateKeyPath,
+      // OpenSSL option to store a bookkeeping file that stores the next serial number used when this CA
+      // issues certificates.
       "-CAcreateserial",
       "-out",
       certPath,
+      // The certificate is valid for the requested number of days.
       "-days",
       String(certificateDays),
       "-sha256",
@@ -200,11 +216,18 @@ async function issueCertificateFromCsr(
 async function writeCertificateExtensionsFile(
   outputDirectoryPath: string,
   dnsNames: string[],
+  ipAddresses: string[],
 ) {
   const certExtensionsPath = getIssuedCertExtensionsPath(outputDirectoryPath);
 
-  const subjectAlternativeNames = dnsNames
+  const dnsAlternativeNames = dnsNames
     .map((dnsName, index) => `DNS.${index + 1}=${dnsName}`)
+    .join("\n");
+  const ipAlternativeNames = ipAddresses
+    .map((ipAddress, index) => `IP.${index + 1}=${ipAddress}`)
+    .join("\n");
+  const subjectAlternativeNames = [dnsAlternativeNames, ipAlternativeNames]
+    .filter(Boolean)
     .join("\n");
 
   const extfileContents = [

--- a/https/certgen/package.json
+++ b/https/certgen/package.json
@@ -4,7 +4,9 @@
     "generate-ca": "node generate-ca.ts",
     "install-ca": "node install-ca.ts",
     "uninstall-ca": "node uninstall-ca.ts",
-    "issue-cert": "node issue-cert.ts"
+    "issue-cert": "node issue-cert.ts",
+    "types": "tsc --noEmit",
+    "test": "node --test certgen.test.ts"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/https/node/https.test.ts
+++ b/https/node/https.test.ts
@@ -41,6 +41,23 @@ test("successful request", async () => {
   expect(responseBody).toBe("HTTPS response");
 });
 
+test("successful request when requesting by IP and certificate includes an IP SAN", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } = await generateCertificates({
+    dnsNames: [],
+    ipAddresses: ["127.0.0.1"],
+  });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  const responseBody = await makeHttpsRequest({
+    requestUrl: `https://127.0.0.1:${serverPort}`,
+    requestOptions: { ca: readFileSync(caRootCertPath) },
+  });
+  expect(responseBody).toBe("HTTPS response");
+});
+
 test("server certificate is not signed by a trusted root certificate", async () => {
   expect.hasAssertions();
 

--- a/https/node/https.test.ts
+++ b/https/node/https.test.ts
@@ -36,7 +36,7 @@ test("successful request", async () => {
   await bootHttpsServer(certPath, privateKeyPath);
 
   const responseBody = await makeHttpsRequest({
-    ca: readFileSync(caRootCertPath),
+    requestOptions: { ca: readFileSync(caRootCertPath) },
   });
   expect(responseBody).toBe("HTTPS response");
 });
@@ -48,7 +48,7 @@ test("server certificate is not signed by a trusted root certificate", async () 
 
   await bootHttpsServer(certPath, privateKeyPath);
 
-  expect(makeHttpsRequest()).rejects.toMatchObject({
+  await expect(makeHttpsRequest({})).rejects.toMatchObject({
     code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
     message: expect.stringContaining("unable to verify the first certificate"),
   });
@@ -62,8 +62,10 @@ test("server certificate is signed correctly, but hostname does not match the re
 
   await bootHttpsServer(certPath, privateKeyPath);
 
-  expect(
-    makeHttpsRequest({ ca: readFileSync(caRootCertPath) }),
+  await expect(
+    makeHttpsRequest({
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
   ).rejects.toMatchObject({
     code: "ERR_TLS_CERT_ALTNAME_INVALID",
     message: expect.stringContaining("does not match certificate's altnames"),
@@ -81,11 +83,51 @@ test("server certificate is signed correctly, but certificate has expired", asyn
 
   await bootHttpsServer(certPath, privateKeyPath);
 
-  expect(
-    makeHttpsRequest({ ca: readFileSync(caRootCertPath) }),
+  await expect(
+    makeHttpsRequest({
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
   ).rejects.toMatchObject({
     code: "CERT_HAS_EXPIRED",
     message: expect.stringContaining("certificate has expired"),
+  });
+});
+
+test("server certificate is signed correctly for localhost, but request uses an IP address", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({ dnsNames: ["localhost"] });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(
+    makeHttpsRequest({
+      requestUrl: `https://127.0.0.1:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    message: expect.stringContaining("does not match certificate's altnames"),
+  });
+});
+
+test("request to an IP fails when the certificate does not contain a SAN extension", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({ includeSubjectAltName: false });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(
+    makeHttpsRequest({
+      requestUrl: `https://127.0.0.1:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    message: expect.stringContaining("does not match certificate's altnames"),
   });
 });
 
@@ -120,12 +162,15 @@ async function bootHttpsServer(certPath: string, privateKeyPath: string) {
   });
 }
 
-function makeHttpsRequest(options?: https.RequestOptions) {
+function makeHttpsRequest({
+  requestUrl = `https://localhost:${serverPort}`,
+  requestOptions = {},
+}: {
+  requestUrl?: string;
+  requestOptions?: https.RequestOptions;
+}) {
   return new Promise<string>((resolve, reject) => {
-    const request = https.get(
-      `https://localhost:${serverPort}`,
-      options ?? {},
-      (response) => {
+    const request = https.get(requestUrl, requestOptions, (response) => {
         let data = "";
 
         response.on("data", (chunk: Buffer) => {
@@ -135,8 +180,7 @@ function makeHttpsRequest(options?: https.RequestOptions) {
         response.on("end", () => {
           resolve(data);
         });
-      },
-    );
+      });
 
     request.on("error", reject);
   });

--- a/https/node/https.test.ts
+++ b/https/node/https.test.ts
@@ -1,9 +1,10 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import * as https from "node:https";
 import { resolve } from "node:path";
 import { afterEach, expect, test } from "vitest";
 import { generateCa } from "../certgen/generate-ca.ts";
 import { issueCertificate } from "../certgen/issue-cert.ts";
+import { getIssuedCertExtensionsPath } from "../certgen/util/paths.ts";
 
 const serverPort = 8080;
 let server: https.Server | undefined;
@@ -27,11 +28,11 @@ afterEach(async () => {
   server = undefined;
 });
 
-test("successful request", async () => {
+test("successful request when certificate has a DNS SAN", async () => {
   expect.hasAssertions();
 
   const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates();
+    await generateCertificates({ dnsNames: ["localhost"] });
 
   await bootHttpsServer(certPath, privateKeyPath);
 
@@ -41,13 +42,14 @@ test("successful request", async () => {
   expect(responseBody).toBe("HTTPS response");
 });
 
-test("successful request when requesting by IP and certificate includes an IP SAN", async () => {
+test("successful request when certificate has an IP SAN", async () => {
   expect.hasAssertions();
 
-  const { caRootCertPath, privateKeyPath, certPath } = await generateCertificates({
-    dnsNames: [],
-    ipAddresses: ["127.0.0.1"],
-  });
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({
+      dnsNames: [],
+      ipAddresses: ["127.0.0.1"],
+    });
 
   await bootHttpsServer(certPath, privateKeyPath);
 
@@ -58,14 +60,35 @@ test("successful request when requesting by IP and certificate includes an IP SA
   expect(responseBody).toBe("HTTPS response");
 });
 
-test("server certificate is not signed by a trusted root certificate", async () => {
+test("failed request using domain when certificate has IP SAN", async () => {
   expect.hasAssertions();
 
-  const { privateKeyPath, certPath } = await generateCertificates();
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({ dnsNames: ["localhost"] });
 
   await bootHttpsServer(certPath, privateKeyPath);
 
-  await expect(makeHttpsRequest({})).rejects.toMatchObject({
+  await expect(
+    makeHttpsRequest({
+      requestUrl: `https://127.0.0.1:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    message: expect.stringContaining("does not match certificate's altnames"),
+  });
+});
+
+test("server certificate is not signed by a trusted root certificate", async () => {
+  expect.hasAssertions();
+
+  const { privateKeyPath, certPath } = await generateCertificates({
+    dnsNames: ["localhost"],
+  });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(makeHttpsRequest()).rejects.toMatchObject({
     code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
     message: expect.stringContaining("unable to verify the first certificate"),
   });
@@ -110,30 +133,15 @@ test("server certificate is signed correctly, but certificate has expired", asyn
   });
 });
 
-test("server certificate is signed correctly for localhost, but request uses an IP address", async () => {
+test("request to an IP fails when the certificate omits SAN but still writes the ext file", async () => {
   expect.hasAssertions();
 
+  const issuedCertDirectoryPath = resolve(process.cwd(), "build-issued-cert");
   const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates({ dnsNames: ["localhost"] });
-
-  await bootHttpsServer(certPath, privateKeyPath);
-
-  await expect(
-    makeHttpsRequest({
-      requestUrl: `https://127.0.0.1:${serverPort}`,
-      requestOptions: { ca: readFileSync(caRootCertPath) },
-    }),
-  ).rejects.toMatchObject({
-    code: "ERR_TLS_CERT_ALTNAME_INVALID",
-    message: expect.stringContaining("does not match certificate's altnames"),
-  });
-});
-
-test("request to an IP fails when the certificate does not contain a SAN extension", async () => {
-  expect.hasAssertions();
-
-  const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates({ includeSubjectAltName: false });
+    await generateCertificates({ dnsNames: [], ipAddresses: [] });
+  expect(existsSync(getIssuedCertExtensionsPath(issuedCertDirectoryPath))).toBe(
+    true,
+  );
 
   await bootHttpsServer(certPath, privateKeyPath);
 
@@ -185,19 +193,19 @@ function makeHttpsRequest({
 }: {
   requestUrl?: string;
   requestOptions?: https.RequestOptions;
-}) {
+} = {}) {
   return new Promise<string>((resolve, reject) => {
     const request = https.get(requestUrl, requestOptions, (response) => {
-        let data = "";
+      let data = "";
 
-        response.on("data", (chunk: Buffer) => {
-          data += chunk.toString();
-        });
-
-        response.on("end", () => {
-          resolve(data);
-        });
+      response.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
       });
+
+      response.on("end", () => {
+        resolve(data);
+      });
+    });
 
     request.on("error", reject);
   });

--- a/https/node/https.test.ts
+++ b/https/node/https.test.ts
@@ -60,80 +60,7 @@ test("successful request when certificate has an IP SAN", async () => {
   expect(responseBody).toBe("HTTPS response");
 });
 
-test("failed request using domain when certificate has IP SAN", async () => {
-  expect.hasAssertions();
-
-  const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates({ dnsNames: ["localhost"] });
-
-  await bootHttpsServer(certPath, privateKeyPath);
-
-  await expect(
-    makeHttpsRequest({
-      requestUrl: `https://127.0.0.1:${serverPort}`,
-      requestOptions: { ca: readFileSync(caRootCertPath) },
-    }),
-  ).rejects.toMatchObject({
-    code: "ERR_TLS_CERT_ALTNAME_INVALID",
-    message: expect.stringContaining("does not match certificate's altnames"),
-  });
-});
-
-test("server certificate is not signed by a trusted root certificate", async () => {
-  expect.hasAssertions();
-
-  const { privateKeyPath, certPath } = await generateCertificates({
-    dnsNames: ["localhost"],
-  });
-
-  await bootHttpsServer(certPath, privateKeyPath);
-
-  await expect(makeHttpsRequest()).rejects.toMatchObject({
-    code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-    message: expect.stringContaining("unable to verify the first certificate"),
-  });
-});
-
-test("server certificate is signed correctly, but hostname does not match the requested hostname", async () => {
-  expect.hasAssertions();
-
-  const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates({ dnsNames: ["example.test"] });
-
-  await bootHttpsServer(certPath, privateKeyPath);
-
-  await expect(
-    makeHttpsRequest({
-      requestOptions: { ca: readFileSync(caRootCertPath) },
-    }),
-  ).rejects.toMatchObject({
-    code: "ERR_TLS_CERT_ALTNAME_INVALID",
-    message: expect.stringContaining("does not match certificate's altnames"),
-  });
-});
-
-test("server certificate is signed correctly, but certificate has expired", async () => {
-  expect.hasAssertions();
-
-  const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates({
-      certificateDays: 0,
-      verifyCertificateAfterCreation: false,
-    });
-
-  await bootHttpsServer(certPath, privateKeyPath);
-
-  await expect(
-    makeHttpsRequest({
-      requestOptions: { ca: readFileSync(caRootCertPath) },
-    }),
-  ).rejects.toMatchObject({
-    code: "CERT_HAS_EXPIRED",
-    message: expect.stringContaining("certificate has expired"),
-  });
-});
-
-test("request to an IP fails when the certificate omits SAN but still writes the ext file", async () => {
+test("failed request due to certificate with no SANs", async () => {
   expect.hasAssertions();
 
   const issuedCertDirectoryPath = resolve(process.cwd(), "build-issued-cert");
@@ -153,6 +80,153 @@ test("request to an IP fails when the certificate omits SAN but still writes the
   ).rejects.toMatchObject({
     code: "ERR_TLS_CERT_ALTNAME_INVALID",
     message: expect.stringContaining("does not match certificate's altnames"),
+  });
+});
+
+// As this test shows, when a certificate has no SAN entries, Node can fall back to
+// validating the request hostname against the certificate Common Name (CN).
+// SAN is still the modern, recommended place for certificate identities, and
+// publicly trusted TLS certificates are generally expected to include SANs.
+// https://cabforum.org/working-groups/server/baseline-requirements/requirements/#7143-subscriber-certificate-common-name-attribute
+test("successful request when certificate has no SANs but CN matches request domain", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({
+      commonName: "localhost",
+      dnsNames: [],
+      ipAddresses: [],
+    });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  const responseBody = await makeHttpsRequest({
+    requestOptions: { ca: readFileSync(caRootCertPath) },
+  });
+  expect(responseBody).toBe("HTTPS response");
+});
+
+test("failed request when certificate has DNS SAN that does not match request domain", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({ dnsNames: ["example.test"] });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(
+    makeHttpsRequest({
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    message: expect.stringContaining("does not match certificate's altnames"),
+  });
+});
+
+test("failed request when certificate has DNS SAN but request uses an IP", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({ dnsNames: ["localhost"] });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(
+    makeHttpsRequest({
+      requestUrl: `https://127.0.0.1:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    message: expect.stringContaining("does not match certificate's altnames"),
+  });
+});
+
+test("failed request when certificate has IP SAN but request uses a domain", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({
+      commonName: "unused.invalid",
+      ipAddresses: ["127.0.0.1"],
+    });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(
+    makeHttpsRequest({
+      requestUrl: `https://localhost:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    message: expect.stringContaining("does not match certificate's altnames"),
+  });
+});
+
+test("successful requests matching multiple SANs - DNS and IP", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({
+      dnsNames: ["localhost"],
+      ipAddresses: ["127.0.0.1"],
+    });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  // Domain request should work.
+  expect(
+    await makeHttpsRequest({
+      requestUrl: `https://localhost:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).toBe("HTTPS response");
+
+  // IP request should work.
+  expect(
+    await makeHttpsRequest({
+      requestUrl: `https://127.0.0.1:${serverPort}`,
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).toBe("HTTPS response");
+});
+
+test("server certificate is not signed by a trusted root certificate", async () => {
+  expect.hasAssertions();
+
+  const { privateKeyPath, certPath } = await generateCertificates({
+    dnsNames: ["localhost"],
+  });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(makeHttpsRequest()).rejects.toMatchObject({
+    code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+    message: expect.stringContaining("unable to verify the first certificate"),
+  });
+});
+
+test("failed request due to expired certificate", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates({
+      dnsNames: ["localhost"],
+      certificateDays: 0,
+      verifyCertificateAfterCreation: false,
+    });
+
+  await bootHttpsServer(certPath, privateKeyPath);
+
+  await expect(
+    makeHttpsRequest({
+      requestOptions: { ca: readFileSync(caRootCertPath) },
+    }),
+  ).rejects.toMatchObject({
+    code: "CERT_HAS_EXPIRED",
+    message: expect.stringContaining("certificate has expired"),
   });
 });
 


### PR DESCRIPTION
Add more node HTTPS tests. Cover various combinations of subject alternative name in certificates:
- DNS only, success
- DNS only, fail due to request using IP
- IP only, success
- IP only, fail due to request using domain
- DNS and IP
- Node still accepting only a certificate with no SAN and falling back to matching on common name (CN)