### PR TITLE
Support HTTPS termination in reverse proxy

### DIFF
--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -1,4 +1,6 @@
 import * as http from "node:http";
+import * as https from "node:https";
+import type { TlsOptions } from "node:tls";
 
 import { afterEach, expect, test, vi } from "vitest";
 
@@ -378,6 +380,78 @@ test("replaces forwarding headers and preserves other headers", async () => {
   expect(forwardedHeaders.xForwardedProto).toBe("http");
   expect(forwardedHeaders.xCustomHeader).toBe("keep-me");
 });
+
+test("supports HTTPS termination for client -> proxy while keeping backend HTTP", async () => {
+  await createBackendServer({
+    port: 3000,
+    handleRequest: (request, response) => {
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "application/json");
+      response.end(
+        JSON.stringify({
+          path: request.url,
+          xForwardedProto: request.headers["x-forwarded-proto"],
+        }),
+      );
+    },
+  });
+
+  const { proxyPort } = await createProxyServer({
+    port: 0,
+    proxyProtocol: "https",
+    tls: getTestTlsOptions(),
+    backends: {
+      "example.com": { servers: [{ url: "http://localhost:3000" }] },
+    },
+  });
+
+  const response = await makeHttpsRequest({
+    headers: {
+      Host: "example.com",
+    },
+    path: "/via-https-proxy",
+    port: proxyPort,
+  });
+
+  expect(response.statusCode).toBe(200);
+  const payload = JSON.parse(response.body) as {
+    path?: string;
+    xForwardedProto?: string;
+  };
+  expect(payload.path).toBe("/via-https-proxy");
+  expect(payload.xForwardedProto).toBe("https");
+});
+
+test("throws when HTTPS proxyProtocol is configured without TLS key/cert", () => {
+  expect(() =>
+    boot({
+      port: 0,
+      proxyProtocol: "https",
+      backends: {
+        "example.com": { servers: [{ url: "http://localhost:3000" }] },
+      },
+    }),
+  ).toThrow(
+    'ProxyConfig.tls must include both "key" and "cert" when proxyProtocol is "https"',
+  );
+});
+
+test("throws when HTTPS proxyProtocol is configured with cert but no key", () => {
+  expect(() =>
+    boot({
+      port: 0,
+      proxyProtocol: "https",
+      tls: {
+        cert: TEST_CERT,
+      },
+      backends: {
+        "example.com": { servers: [{ url: "http://localhost:3000" }] },
+      },
+    }),
+  ).toThrow(
+    'ProxyConfig.tls must include both "key" and "cert" when proxyProtocol is "https"',
+  );
+});
 test("one client can make requests to two different paths on the same backend", async () => {
   await createBackendServer({
     port: 3000,
@@ -739,6 +813,141 @@ function makeRequest({
     request.end();
   });
 }
+
+function makeHttpsRequest({
+  body,
+  headers = {},
+  method = "GET",
+  path = "/",
+  port,
+  setHost = true,
+}: {
+  body?: string;
+  headers?: http.OutgoingHttpHeaders;
+  method?: string;
+  path?: string;
+  port: number;
+  setHost?: boolean;
+}) {
+  return new Promise<{
+    body: string;
+    closed: boolean;
+    ended: boolean;
+    headers: http.IncomingHttpHeaders;
+    statusCode: number | undefined;
+  }>((resolve, reject) => {
+    const request = https.request(
+      {
+        hostname: "127.0.0.1",
+        method,
+        port,
+        path,
+        headers,
+        setHost,
+        rejectUnauthorized: false,
+      },
+      (response) => {
+        let body = "";
+
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          resolve({
+            body,
+            closed: false,
+            ended: true,
+            headers: response.headers,
+            statusCode: response.statusCode,
+          });
+        });
+        response.on("close", () => {
+          if (!response.complete) {
+            resolve({
+              body,
+              closed: true,
+              ended: false,
+              headers: response.headers,
+              statusCode: response.statusCode,
+            });
+          }
+        });
+        response.on("error", () => {
+          resolve({
+            body,
+            closed: true,
+            ended: false,
+            headers: response.headers,
+            statusCode: response.statusCode,
+          });
+        });
+      },
+    );
+
+    request.on("error", reject);
+    if (body != null) {
+      request.write(body);
+    }
+    request.end();
+  });
+}
+
+function getTestTlsOptions(): TlsOptions {
+  return {
+    key: TEST_KEY,
+    cert: TEST_CERT,
+  };
+}
+
+const TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDEg+RsNWxPFnea
+aDqz7dFxc3k/3DR+8QAW6S8UWhhbyTBmUittFqcGXYzljp3FmK01vGGxkulDqhQL
+eapKwh3R0CUIz8vlf8ulEOtlpyE3VoIiHMGUl1lNhyz//ensaY7XvwIi0FWfTzel
+OXvGRS39mWeqhy7LK9TpaEsAH0SU9CuoSmmce9z41q2OYBUxG9LXzcNwU15CWupz
+3wJLSxMwkDMhyJEr0JNufcz4zPW3vXhilf1+0IpBdYk7zb/1cI3nS6AIgP0ASg56
+h832+hXWFfSqCrPgX1LKq/35hxACYtmLKsRuunAhkp6E0hkUAkFd4oje/qQUMYHJ
+/i/STRznAgMBAAECggEAIe/9JMrdF5NzuFDDwosRnpwolmS7FCkesNY4cTVV+5P1
+LdaG9WHyGmFRkdtdV+CUGTGdVYNfkXXv3EN4q0x2xeNCYhEwz0OQscMIRBfm3p2r
+/6QjsjupCoCLvvHk0hUwvAWaotSD1O1jWL9ips0Psjop8wNBi4jYTi7atPyxZV+w
+CctBczBbckotdX5ztQyto9hOqgyfaRxhw5d9PXMIhadCf+TRwMOMb/ZcurOtM5Ro
+XLFYsIZsqS0quCXSikINgBoXa6uKExXEV0sEn6cskIXdkT9fGXA/yvOAvRSZ+i99
+EA3ItqSUvk4LvXMOQzTiePjdABMhuQGuDqE7rI88UQKBgQDtboQWjvMG68BqPdEw
+/NECuZWhEpB8fUSx8ioziDqjCV34/7EKZHiFfLU09JajCL/DguvP5wEWyWtgXtlA
+fuhgDmMobdn4qafaQqJQaoKhNPqDTJ2yAvq5Fygv7H3AvXKzZXhcV5pBRLjyztbz
+EfhHC3jIFbnPKO5nMoGE2GFc0wKBgQDT4jXlyzhvNhSvcK3Oi/RB+Czy8vii8NYZ
+YjzdIFaOoLWjmfEgr8p6hqSGFAlEuNEDVg7vtfVsguaPV4lzM6hCEKZuVfW8fKMH
+/0X7+QqncCZ6kXkfhbyyDqO0V70bAIFsl7jQIJiqNK8Z4EKhaRB/0lClk7/tkgWO
+e9FM+iBjHQKBgAmTQmpye2SVD155fb0/BOLaPymOyRrsJmASxxbq8Ipwr0SCc05a
+/O1NOTWYg5axnKIy3nW0+DtGBjmNua87Lv3otqEDxR2dIfLQayFZGkmMDGpNJbLv
+IdNjFrDQFcY3HbAUcIUw1zy4m8jXBJ4q5FthIA7ZqXOsT+kDhWupGkwXAoGBAK3z
+TSR3DsHeuGTAMTEdHU77nItohk/fQSZdzHIOFoHJ1tWVkKyxJZ4p4/Bfiqxsvsvq
+XyDVVcPcQ8TyrNlzU3PJj5mN4Mz51i6+mIohD2ofXLfLrpD+jsfv1N4+GfaNF7Q7
+a3MTD8LMteSchJdXVkBaPfNxtWQpOX6ckFyODQDRAoGBAKJ/Z15dw0uCCB6DeT2s
+UE6JtuPaR65Q4R0rL8XjMNxvjrsGfOZRafnbRCeqUuMnazs8kw+SsaW1mfX6nzfC
+xsXNXWcVyOVl1lw9JIaJZx4U9XtZaO28RVfC/+yNH3d8lIuFHC8vhS2EkRttdksQ
+mUESFuec2m/xVju8zWpvliNv
+-----END PRIVATE KEY-----`;
+
+const TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUanN+MKESX21jIGjQ5w/HjsHxqigwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDQwMTAwMDAwMFoXDTM2MDMy
+OTAwMDAwMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAxIPkbDVsTxZ3mmg6s+3RcXN5P9w0fvEAFukvFFoYW8kw
+ZlIrbRanBl2M5Y6dxZitNbxhsZLpQ6oUC3mqSsId0dAlCM/L5X/LpRDrZachN1aC
+IhzBlJdZTYcs//3p7GmO178CItBVn083pTl7xkUt/ZlnqocuyyvU6WhLAB9ElPQr
+qEppnHvc+NatjmAVMRvS183DcFNeQlrqc98CS0sTMJAzIciRK9CTbn3M+Mz1t714
+YpX9ftCKQXWJO82/9XCN50ugCID9AEoOeofN9voV1hX0qgqz4F9Syqv9+YcQAmLZ
+iyrEbrpwIZKehNIZFAJBXeKI3v6kFDGByf4v0k0c5wIDAQABo1MwUTAdBgNVHQ4E
+FgQUV1NKNTMQ+T4YdymIV58GTufHaGYwHwYDVR0jBBgwFoAUV1NKNTMQ+T4YdymI
+V58GTufHaGYwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAbnP+
+JGZFBLut/p1cAWAuCiY4VgAD1oswdROyVMmRhgivSYBytVN4rhxmFAZzAtZ2GTdS
+eO8a5VGv1fxc9gTNm3TnY0l9joYNNNIRjaQMaucprx9Dsu6Nc6jVp3rz1sHdYSgl
+XMAZNYDLn6TvmMadtw9JstMcHRbIn95LK+MoSs2Y7tVVz9yO5z0w3dBCbXTD2atW
+FV2oGtpaRPqaHuv28eJErznlz65FK1aIFDBP/Or/A7rDHsKlRvFLO/6gG/eyjRiX
+WX02s836Zks0PUOCX3cN+/+Y2xjAesmHT7bPiaRQ84Smr9e3KHdVbGxcHeuugm/R
+HfC4A++9vTXwh1hctQ==
+-----END CERTIFICATE-----`;
 
 function readRequestBody(request: http.IncomingMessage) {
   return new Promise<string>((resolve, reject) => {

--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -410,7 +410,9 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
   });
 
   const { caRootCertPath, privateKeyPath, certPath } =
-    await generateCertificates();
+    await generateCertificates({
+      dnsNames: ["example.com"],
+    });
 
   const { proxyPort } = await createProxyServer({
     port: 0,
@@ -429,8 +431,6 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
     port: proxyPort,
     requestOptions: {
       ca: readFileSync(caRootCertPath),
-      // Server name for the SNI (Server Name Indication) TLS extension. Tells the server which certificate to return.
-      servername: "localhost",
     },
   });
 

--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -394,7 +394,7 @@ test("replaces forwarding headers and preserves other headers", async () => {
   expect(forwardedHeaders.xCustomHeader).toBe("keep-me");
 });
 
-test("supports HTTPS termination for client -> proxy while keeping backend HTTP", async () => {
+test("supports HTTPS termination for client -> proxy for multiple domains", async () => {
   await createBackendServer({
     port: 3000,
     handleRequest: (request, response) => {
@@ -408,10 +408,24 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
       );
     },
   });
+  await createBackendServer({
+    port: 4000,
+    handleRequest: (request, response) => {
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "application/json");
+      response.end(
+        JSON.stringify({
+          path: request.url,
+          xForwardedProto: request.headers["x-forwarded-proto"],
+        }),
+      );
+    },
+  });
 
+  // Generate a certificate for the reverse proxy supporting all domains it forwards for.
   const { caRootCertPath, privateKeyPath, certPath } =
     await generateCertificates({
-      dnsNames: ["example.com"],
+      dnsNames: ["example.com", "example.test"],
     });
 
   const { proxyPort } = await createProxyServer({
@@ -420,10 +434,12 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
     tls: { key: readFileSync(privateKeyPath), cert: readFileSync(certPath) },
     backends: {
       "example.com": { servers: [{ url: "http://localhost:3000" }] },
+      "example.test": { servers: [{ url: "http://localhost:4000" }] },
     },
   });
 
-  const response = await makeHttpsRequest({
+  // Check example.com HTTPS request succeeds.
+  const responseCom = await makeHttpsRequest({
     headers: {
       Host: "example.com",
     },
@@ -434,13 +450,33 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
     },
   });
 
-  expect(response.statusCode).toBe(200);
-  const payload = JSON.parse(response.body) as {
+  expect(responseCom.statusCode).toBe(200);
+  const payloadCom = JSON.parse(responseCom.body) as {
     path?: string;
     xForwardedProto?: string;
   };
-  expect(payload.path).toBe("/via-https-proxy");
-  expect(payload.xForwardedProto).toBe("https");
+  expect(payloadCom.path).toBe("/via-https-proxy");
+  expect(payloadCom.xForwardedProto).toBe("https");
+
+  // Check we can do our different domain and HTTPS validation still succeeds - example.test
+  const responseTest = await makeHttpsRequest({
+    headers: {
+      Host: "example.test",
+    },
+    path: "/via-https-proxy",
+    port: proxyPort,
+    requestOptions: {
+      ca: readFileSync(caRootCertPath),
+    },
+  });
+
+  expect(responseTest.statusCode).toBe(200);
+  const payloadTest = JSON.parse(responseTest.body) as {
+    path?: string;
+    xForwardedProto?: string;
+  };
+  expect(payloadTest.path).toBe("/via-https-proxy");
+  expect(payloadTest.xForwardedProto).toBe("https");
 });
 
 test("throws when HTTPS proxyProtocol is configured without TLS key/cert", () => {

--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -2,12 +2,15 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import * as http from "node:http";
 import * as https from "node:https";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { TlsOptions } from "node:tls";
 
 import { afterEach, expect, test, vi } from "vitest";
 
-import { issueCertificate } from "../https/certgen/issue-cert.ts";
+import {
+  issueCertificate,
+  IssueCertificateOptions,
+} from "../https/certgen/issue-cert.ts";
 import { generateCa } from "../https/certgen/generate-ca.ts";
 import { boot, ProxyConfig } from "./reverse-proxy.js";
 
@@ -220,7 +223,6 @@ test("closes the downstream connection when backend closes mid-response", async 
   expect(response.ended).toBe(false);
 });
 
-
 test("uses 30s backend timeout by default", async () => {
   await createBackendServer({ port: 3000, body: "service on 3000" });
 
@@ -407,10 +409,13 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
     },
   });
 
+  const { caRootCertPath, privateKeyPath, certPath } =
+    await generateCertificates();
+
   const { proxyPort } = await createProxyServer({
     port: 0,
     proxyProtocol: "https",
-    tls: await createTestTlsOptions(),
+    tls: { key: readFileSync(privateKeyPath), cert: readFileSync(certPath) },
     backends: {
       "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
@@ -422,6 +427,11 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
     },
     path: "/via-https-proxy",
     port: proxyPort,
+    requestOptions: {
+      ca: readFileSync(caRootCertPath),
+      // Server name for the SNI (Server Name Indication) TLS extension. Tells the server which certificate to return.
+      servername: "localhost",
+    },
   });
 
   expect(response.statusCode).toBe(200);
@@ -739,7 +749,6 @@ function closeServer(server: http.Server) {
   });
 }
 
-
 function delay(ms: number) {
   return new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
@@ -831,6 +840,7 @@ function makeHttpsRequest({
   method = "GET",
   path = "/",
   port,
+  requestOptions = {},
   setHost = true,
 }: {
   body?: string;
@@ -838,6 +848,7 @@ function makeHttpsRequest({
   method?: string;
   path?: string;
   port: number;
+  requestOptions?: https.RequestOptions;
   setHost?: boolean;
 }) {
   return new Promise<{
@@ -855,7 +866,7 @@ function makeHttpsRequest({
         path,
         headers,
         setHost,
-        rejectUnauthorized: false,
+        ...requestOptions,
       },
       (response) => {
         let body = "";
@@ -904,25 +915,23 @@ function makeHttpsRequest({
   });
 }
 
-async function createTestTlsOptions(): Promise<TlsOptions> {
-  const baseDirectory = mkdtempSync(join(tmpdir(), "proxy-https-test-"));
-  tempDirectories.push(baseDirectory);
-
-  const caDirectory = join(baseDirectory, "ca");
-  const issuedDirectory = join(baseDirectory, "issued");
-
-  await generateCa({ outputDirectoryPath: caDirectory });
-  const { certPath, privateKeyPath } = await issueCertificate({
-    outputDirectoryPath: issuedDirectory,
-    caDirectoryPath: caDirectory,
+async function generateCertificates(
+  options: IssueCertificateOptions = {
     dnsNames: ["localhost"],
     ipAddresses: ["127.0.0.1"],
-  });
+  },
+) {
+  const baseDirectory = mkdtempSync(join(tmpdir(), "proxy-https-test-"));
+  tempDirectories.push(baseDirectory);
+  const caDirectoryPath = join(baseDirectory, "ca");
+  const issuedDirectory = join(baseDirectory, "issued");
 
-  return {
-    key: readFileSync(privateKeyPath),
-    cert: readFileSync(certPath),
-  };
+  await generateCa({ outputDirectoryPath: caDirectoryPath });
+  return issueCertificate({
+    outputDirectoryPath: issuedDirectory,
+    caDirectoryPath,
+    ...options,
+  });
 }
 
 function readRequestBody(request: http.IncomingMessage) {

--- a/proxy/reverse-proxy.test.ts
+++ b/proxy/reverse-proxy.test.ts
@@ -1,13 +1,19 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import * as http from "node:http";
 import * as https from "node:https";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { TlsOptions } from "node:tls";
 
 import { afterEach, expect, test, vi } from "vitest";
 
+import { issueCertificate } from "../https/certgen/issue-cert.ts";
+import { generateCa } from "../https/certgen/generate-ca.ts";
 import { boot, ProxyConfig } from "./reverse-proxy.js";
 
 let proxyServer: http.Server | null = null;
 let backendServers: http.Server[] = [];
+let tempDirectories: string[] = [];
 
 afterEach(async () => {
   await Promise.all(backendServers.map(closeServer));
@@ -17,6 +23,11 @@ afterEach(async () => {
     await closeServer(proxyServer);
     proxyServer = null;
   }
+
+  for (const tempDirectory of tempDirectories) {
+    rmSync(tempDirectory, { recursive: true, force: true });
+  }
+  tempDirectories = [];
 });
 
 test("proxies requests to the backend matched by host", async () => {
@@ -399,7 +410,7 @@ test("supports HTTPS termination for client -> proxy while keeping backend HTTP"
   const { proxyPort } = await createProxyServer({
     port: 0,
     proxyProtocol: "https",
-    tls: getTestTlsOptions(),
+    tls: await createTestTlsOptions(),
     backends: {
       "example.com": { servers: [{ url: "http://localhost:3000" }] },
     },
@@ -442,7 +453,7 @@ test("throws when HTTPS proxyProtocol is configured with cert but no key", () =>
       port: 0,
       proxyProtocol: "https",
       tls: {
-        cert: TEST_CERT,
+        cert: "-----BEGIN CERTIFICATE-----\ninvalid\n-----END CERTIFICATE-----",
       },
       backends: {
         "example.com": { servers: [{ url: "http://localhost:3000" }] },
@@ -893,61 +904,26 @@ function makeHttpsRequest({
   });
 }
 
-function getTestTlsOptions(): TlsOptions {
+async function createTestTlsOptions(): Promise<TlsOptions> {
+  const baseDirectory = mkdtempSync(join(tmpdir(), "proxy-https-test-"));
+  tempDirectories.push(baseDirectory);
+
+  const caDirectory = join(baseDirectory, "ca");
+  const issuedDirectory = join(baseDirectory, "issued");
+
+  await generateCa({ outputDirectoryPath: caDirectory });
+  const { certPath, privateKeyPath } = await issueCertificate({
+    outputDirectoryPath: issuedDirectory,
+    caDirectoryPath: caDirectory,
+    dnsNames: ["localhost"],
+    ipAddresses: ["127.0.0.1"],
+  });
+
   return {
-    key: TEST_KEY,
-    cert: TEST_CERT,
+    key: readFileSync(privateKeyPath),
+    cert: readFileSync(certPath),
   };
 }
-
-const TEST_KEY = `-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDEg+RsNWxPFnea
-aDqz7dFxc3k/3DR+8QAW6S8UWhhbyTBmUittFqcGXYzljp3FmK01vGGxkulDqhQL
-eapKwh3R0CUIz8vlf8ulEOtlpyE3VoIiHMGUl1lNhyz//ensaY7XvwIi0FWfTzel
-OXvGRS39mWeqhy7LK9TpaEsAH0SU9CuoSmmce9z41q2OYBUxG9LXzcNwU15CWupz
-3wJLSxMwkDMhyJEr0JNufcz4zPW3vXhilf1+0IpBdYk7zb/1cI3nS6AIgP0ASg56
-h832+hXWFfSqCrPgX1LKq/35hxACYtmLKsRuunAhkp6E0hkUAkFd4oje/qQUMYHJ
-/i/STRznAgMBAAECggEAIe/9JMrdF5NzuFDDwosRnpwolmS7FCkesNY4cTVV+5P1
-LdaG9WHyGmFRkdtdV+CUGTGdVYNfkXXv3EN4q0x2xeNCYhEwz0OQscMIRBfm3p2r
-/6QjsjupCoCLvvHk0hUwvAWaotSD1O1jWL9ips0Psjop8wNBi4jYTi7atPyxZV+w
-CctBczBbckotdX5ztQyto9hOqgyfaRxhw5d9PXMIhadCf+TRwMOMb/ZcurOtM5Ro
-XLFYsIZsqS0quCXSikINgBoXa6uKExXEV0sEn6cskIXdkT9fGXA/yvOAvRSZ+i99
-EA3ItqSUvk4LvXMOQzTiePjdABMhuQGuDqE7rI88UQKBgQDtboQWjvMG68BqPdEw
-/NECuZWhEpB8fUSx8ioziDqjCV34/7EKZHiFfLU09JajCL/DguvP5wEWyWtgXtlA
-fuhgDmMobdn4qafaQqJQaoKhNPqDTJ2yAvq5Fygv7H3AvXKzZXhcV5pBRLjyztbz
-EfhHC3jIFbnPKO5nMoGE2GFc0wKBgQDT4jXlyzhvNhSvcK3Oi/RB+Czy8vii8NYZ
-YjzdIFaOoLWjmfEgr8p6hqSGFAlEuNEDVg7vtfVsguaPV4lzM6hCEKZuVfW8fKMH
-/0X7+QqncCZ6kXkfhbyyDqO0V70bAIFsl7jQIJiqNK8Z4EKhaRB/0lClk7/tkgWO
-e9FM+iBjHQKBgAmTQmpye2SVD155fb0/BOLaPymOyRrsJmASxxbq8Ipwr0SCc05a
-/O1NOTWYg5axnKIy3nW0+DtGBjmNua87Lv3otqEDxR2dIfLQayFZGkmMDGpNJbLv
-IdNjFrDQFcY3HbAUcIUw1zy4m8jXBJ4q5FthIA7ZqXOsT+kDhWupGkwXAoGBAK3z
-TSR3DsHeuGTAMTEdHU77nItohk/fQSZdzHIOFoHJ1tWVkKyxJZ4p4/Bfiqxsvsvq
-XyDVVcPcQ8TyrNlzU3PJj5mN4Mz51i6+mIohD2ofXLfLrpD+jsfv1N4+GfaNF7Q7
-a3MTD8LMteSchJdXVkBaPfNxtWQpOX6ckFyODQDRAoGBAKJ/Z15dw0uCCB6DeT2s
-UE6JtuPaR65Q4R0rL8XjMNxvjrsGfOZRafnbRCeqUuMnazs8kw+SsaW1mfX6nzfC
-xsXNXWcVyOVl1lw9JIaJZx4U9XtZaO28RVfC/+yNH3d8lIuFHC8vhS2EkRttdksQ
-mUESFuec2m/xVju8zWpvliNv
------END PRIVATE KEY-----`;
-
-const TEST_CERT = `-----BEGIN CERTIFICATE-----
-MIIDCTCCAfGgAwIBAgIUanN+MKESX21jIGjQ5w/HjsHxqigwDQYJKoZIhvcNAQEL
-BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDQwMTAwMDAwMFoXDTM2MDMy
-OTAwMDAwMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEAxIPkbDVsTxZ3mmg6s+3RcXN5P9w0fvEAFukvFFoYW8kw
-ZlIrbRanBl2M5Y6dxZitNbxhsZLpQ6oUC3mqSsId0dAlCM/L5X/LpRDrZachN1aC
-IhzBlJdZTYcs//3p7GmO178CItBVn083pTl7xkUt/ZlnqocuyyvU6WhLAB9ElPQr
-qEppnHvc+NatjmAVMRvS183DcFNeQlrqc98CS0sTMJAzIciRK9CTbn3M+Mz1t714
-YpX9ftCKQXWJO82/9XCN50ugCID9AEoOeofN9voV1hX0qgqz4F9Syqv9+YcQAmLZ
-iyrEbrpwIZKehNIZFAJBXeKI3v6kFDGByf4v0k0c5wIDAQABo1MwUTAdBgNVHQ4E
-FgQUV1NKNTMQ+T4YdymIV58GTufHaGYwHwYDVR0jBBgwFoAUV1NKNTMQ+T4YdymI
-V58GTufHaGYwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAbnP+
-JGZFBLut/p1cAWAuCiY4VgAD1oswdROyVMmRhgivSYBytVN4rhxmFAZzAtZ2GTdS
-eO8a5VGv1fxc9gTNm3TnY0l9joYNNNIRjaQMaucprx9Dsu6Nc6jVp3rz1sHdYSgl
-XMAZNYDLn6TvmMadtw9JstMcHRbIn95LK+MoSs2Y7tVVz9yO5z0w3dBCbXTD2atW
-FV2oGtpaRPqaHuv28eJErznlz65FK1aIFDBP/Or/A7rDHsKlRvFLO/6gG/eyjRiX
-WX02s836Zks0PUOCX3cN+/+Y2xjAesmHT7bPiaRQ84Smr9e3KHdVbGxcHeuugm/R
-HfC4A++9vTXwh1hctQ==
------END CERTIFICATE-----`;
 
 function readRequestBody(request: http.IncomingMessage) {
   return new Promise<string>((resolve, reject) => {

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -1,5 +1,7 @@
 import { createServer } from "node:http";
 import * as http from "node:http";
+import * as https from "node:https";
+import type { TlsOptions } from "node:tls";
 
 /*
   This is a very simple test reverse proxy implementation.
@@ -9,6 +11,16 @@ import * as http from "node:http";
 
 export type ProxyConfig = {
   port?: number;
+  /**
+   * Protocol used for client -> proxy connections.
+   * - http (default)
+   * - https (TLS termination at the proxy)
+   */
+  proxyProtocol?: "http" | "https";
+  /**
+   * TLS certificate options used when proxyProtocol is "https".
+   */
+  tls?: TlsOptions;
   /**
    * Idle timeout in milliseconds for requests to backend servers.
    * This currently covers inactivity on the proxied backend request.
@@ -44,10 +56,18 @@ const DEFAULT_BACKEND_REQUEST_TIMEOUT_MS = 30_000;
 export function boot(opts: ProxyConfig) {
   const port = opts.port ?? process.env.PROXY_PORT ?? 8080;
   const { backends } = opts;
+  const proxyProtocol = opts.proxyProtocol ?? "http";
+  const tlsOptions = opts.tls;
   const backendRequestTimeoutMs =
     opts.backendRequestTimeoutMs ?? DEFAULT_BACKEND_REQUEST_TIMEOUT_MS;
 
-  const server = createServer((clientRequest, proxyResponse) => {
+  if (proxyProtocol === "https" && !hasTlsCertificateAndKey(tlsOptions)) {
+    throw new Error(
+      'ProxyConfig.tls must include both "key" and "cert" when proxyProtocol is "https"',
+    );
+  }
+
+  const requestHandler: http.RequestListener = (clientRequest, proxyResponse) => {
     // Request state.
     let state:
       | { status: "pending" }
@@ -150,6 +170,7 @@ export function boot(opts: ProxyConfig) {
     const forwardedHeaders = getProxiedRequestHeaders({
       proxyRequest: clientRequest,
       hostHeader,
+      proxyProtocol,
     });
 
     // Make request to backend.
@@ -213,13 +234,28 @@ export function boot(opts: ProxyConfig) {
 
     // Proxy the client request data to the backend request.
     clientRequest.pipe(backendRequest);
-  });
+  };
+
+  const server =
+    proxyProtocol === "https"
+      ? https.createServer(
+          // TLS options are validated above for HTTPS mode.
+          tlsOptions as TlsOptions,
+          requestHandler,
+        )
+      : createServer(requestHandler);
 
   server.listen(port, () => {
-    console.log(`Listening on http://localhost:${port}`);
+    console.log(`Listening on ${proxyProtocol}://localhost:${port}`);
   });
 
   return server;
+}
+
+function hasTlsCertificateAndKey(
+  tlsOptions: TlsOptions | undefined,
+): tlsOptions is TlsOptions & { key: NonNullable<TlsOptions["key"]>; cert: NonNullable<TlsOptions["cert"]> } {
+  return tlsOptions?.key != null && tlsOptions.cert != null;
 }
 
 function getHostnameFromHostHeader(hostHeader: string) {
@@ -289,9 +325,11 @@ function getServerDetails({
 function getProxiedRequestHeaders({
   proxyRequest,
   hostHeader,
+  proxyProtocol,
 }: {
   proxyRequest: http.IncomingMessage;
   hostHeader: string;
+  proxyProtocol: "http" | "https";
 }) {
   const forwardedHeaders: http.OutgoingHttpHeaders = {
     ...proxyRequest.headers,
@@ -306,7 +344,7 @@ function getProxiedRequestHeaders({
     forwardedHeaders["x-forwarded-for"] = remoteAddress;
   }
   forwardedHeaders["x-forwarded-host"] = hostHeader;
-  forwardedHeaders["x-forwarded-proto"] = "http";
+  forwardedHeaders["x-forwarded-proto"] = proxyProtocol;
 
   return forwardedHeaders;
 }

--- a/proxy/reverse-proxy.ts
+++ b/proxy/reverse-proxy.ts
@@ -61,13 +61,19 @@ export function boot(opts: ProxyConfig) {
   const backendRequestTimeoutMs =
     opts.backendRequestTimeoutMs ?? DEFAULT_BACKEND_REQUEST_TIMEOUT_MS;
 
-  if (proxyProtocol === "https" && !hasTlsCertificateAndKey(tlsOptions)) {
+  if (
+    proxyProtocol === "https" &&
+    (tlsOptions?.key == null || tlsOptions?.cert == null)
+  ) {
     throw new Error(
       'ProxyConfig.tls must include both "key" and "cert" when proxyProtocol is "https"',
     );
   }
 
-  const requestHandler: http.RequestListener = (clientRequest, proxyResponse) => {
+  const requestHandler: http.RequestListener = (
+    clientRequest,
+    proxyResponse,
+  ) => {
     // Request state.
     let state:
       | { status: "pending" }
@@ -250,12 +256,6 @@ export function boot(opts: ProxyConfig) {
   });
 
   return server;
-}
-
-function hasTlsCertificateAndKey(
-  tlsOptions: TlsOptions | undefined,
-): tlsOptions is TlsOptions & { key: NonNullable<TlsOptions["key"]>; cert: NonNullable<TlsOptions["cert"]> } {
-  return tlsOptions?.key != null && tlsOptions.cert != null;
 }
 
 function getHostnameFromHostHeader(hostHeader: string) {


### PR DESCRIPTION
Added an option for HTTPS termination in the reverse proxy, but still support a HTTP proxy.

Added a test including a certificate that is valid for multiple different domains. This is important for a reverse proxy, in the case it forwards to multiple domains.