### PR TITLE
Add mutual TLS (mTLS) tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules/**
+**/build-test/**
 .idea
 *.DS_Store

--- a/https/certgen/.gitignore
+++ b/https/certgen/.gitignore
@@ -1,4 +1,3 @@
 build-ca
 build-issued-cert
-build-test-ca
-build-test-issued-cert
+build-test

--- a/https/certgen/README.md
+++ b/https/certgen/README.md
@@ -34,15 +34,24 @@ This script issues a TLS certificate from a CSR using the CA we generated. You c
 generate new certificates, each signed by the same generated certificate authority. The CLI defaults to a
 certificate valid for `localhost`.
 
-When using `issueCertificate(...)` programmatically, the SAN extension is derived from `dnsNames` and
+- When using `issueCertificate(...)` programmatically, the SAN extension is derived from `dnsNames` and
 `ipAddresses`. If both arrays are empty, the certificate is issued without SAN entries.
 `commonName` is configurable; by default it uses the first DNS SAN, otherwise the first IP SAN,
-otherwise `common-name-default`.
+otherwise `common-name-default`. 
+- `extendedKeyUsage` controls the Extended Key Usage written to the
+leaf certificate.
+- Set `generatePkcs12: true` to also create a `.p12` bundle containing the issued
+certificate, private key, and CA certificate.
 
 Output directory `build-issued-cert` containing:
 - `private-key.key`: The private key for the issued certificate.
 - `cert.crt`: The issued certificate.
+- `cert.p12`: Optional PKCS#12 bundle created when `generatePkcs12` is enabled.
 - `cert.csr`: The certificate signing request used to issue the certificate.
 - `cert-v3.ext`: Extensions used as part of generating the certificate.
 
 You can use the private key and certificate to boot an HTTPS server.
+
+## Useful OpenSSL commands
+- View a certificate's contents: `openssl x509 -in path/to/cert.crt -text -noout`
+- View a PKCS#12 bundle's contents: `openssl pkcs12 -in path/to/cert.p12 -info -noout`

--- a/https/certgen/certgen.test.ts
+++ b/https/certgen/certgen.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import test, { afterEach } from "node:test";
 import { generateCa } from "./generate-ca.ts";
 import { openssl } from "../openssl-node/openssl-node.ts";
-
-import { issueCertificate, verifyCertificate } from "./issue-cert.ts";
+import { issueCertificate } from "./issue-cert.ts";
+import { verifyCertificate } from "./verify-cert.ts";
 
 const buildTestDirectoryPath = "build-test";
 afterEach(async () => {

--- a/https/certgen/certgen.test.ts
+++ b/https/certgen/certgen.test.ts
@@ -36,7 +36,6 @@ test("generate-ca output can be used by issue-cert and verified explicitly", asy
     caDirectoryPath,
     dnsNames: ["localhost"],
     generatePkcs12: true,
-    verifyCertificateAfterCreation: false,
   });
 
   await assertPathMatchesAndFileExists(

--- a/https/certgen/certgen.test.ts
+++ b/https/certgen/certgen.test.ts
@@ -1,69 +1,132 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
-import test from "node:test";
+import { join } from "node:path";
+import test, { afterEach } from "node:test";
 import { generateCa } from "./generate-ca.ts";
+import { openssl } from "../openssl-node/openssl-node.ts";
+
 import { issueCertificate, verifyCertificate } from "./issue-cert.ts";
 
+const buildTestDirectoryPath = "build-test";
+afterEach(async () => {
+  await rm(buildTestDirectoryPath, { recursive: true, force: true });
+});
+
 test("generate-ca output can be used by issue-cert and verified explicitly", async () => {
-  try {
-    // Generate certificate authority artifacts.
-    const { caPrivateKeyPath, caRootCertPath } = await generateCa({
-      outputDirectoryPath: "build-test-ca",
-    });
+  const caDirectoryPath = join(buildTestDirectoryPath, "ca");
+  const issuedCertificateDirectoryPath = join(buildTestDirectoryPath, "issued");
 
-    await assertPathMatchesAndFileExists(
-      caPrivateKeyPath,
-      "build-test-ca/ca-private-key.key",
-    );
-    await assertPathMatchesAndFileExists(
-      caRootCertPath,
-      "build-test-ca/ca-root.crt",
-    );
+  // Generate certificate authority artifacts.
+  const { caPrivateKeyPath, caRootCertPath } = await generateCa({
+    outputDirectoryPath: caDirectoryPath,
+  });
 
-    // Issue a certificate signed by the certificate authority.
-    const issuedCertificate = await issueCertificate({
-      outputDirectoryPath: "build-test-issued-cert",
-      caDirectoryPath: "build-test-ca",
-      dnsNames: ["localhost"],
-      verifyCertificateAfterCreation: false,
-    });
+  await assertPathMatchesAndFileExists(
+    caPrivateKeyPath,
+    join(caDirectoryPath, "ca-private-key.key"),
+  );
+  await assertPathMatchesAndFileExists(
+    caRootCertPath,
+    join(caDirectoryPath, "ca-root.crt"),
+  );
 
-    await assertPathMatchesAndFileExists(
-      issuedCertificate.privateKeyPath,
-      "build-test-issued-cert/private-key.key",
-    );
-    await assertPathMatchesAndFileExists(
-      issuedCertificate.certCsrPath,
-      "build-test-issued-cert/cert.csr",
-    );
-    await assertPathMatchesAndFileExists(
-      issuedCertificate.certPath,
-      "build-test-issued-cert/cert.crt",
-    );
-    assert.equal(
-      issuedCertificate.caPrivateKeyPath,
-      "build-test-ca/ca-private-key.key",
-    );
-    assert.equal(issuedCertificate.caRootCertPath, "build-test-ca/ca-root.crt");
+  // Issue a certificate signed by the certificate authority.
+  const issuedCertificate = await issueCertificate({
+    outputDirectoryPath: issuedCertificateDirectoryPath,
+    caDirectoryPath,
+    dnsNames: ["localhost"],
+    verifyCertificateAfterCreation: false,
+  });
 
-    await assertFileExistsWithContent("build-test-issued-cert/cert-v3.ext");
+  await assertPathMatchesAndFileExists(
+    issuedCertificate.privateKeyPath,
+    join(issuedCertificateDirectoryPath, "private-key.key"),
+  );
+  await assertPathMatchesAndFileExists(
+    issuedCertificate.certCsrPath,
+    join(issuedCertificateDirectoryPath, "cert.csr"),
+  );
+  await assertPathMatchesAndFileExists(
+    issuedCertificate.certPath,
+    join(issuedCertificateDirectoryPath, "cert.crt"),
+  );
+  assert.equal(
+    issuedCertificate.caPrivateKeyPath,
+    join(caDirectoryPath, "ca-private-key.key"),
+  );
+  assert.equal(
+    issuedCertificate.caRootCertPath,
+    join(caDirectoryPath, "ca-root.crt"),
+  );
 
-    // Verify the issues certificate is signed by the CA.
-    const verificationResult = await verifyCertificate(
-      "build-test-ca/ca-root.crt",
-      issuedCertificate.certPath,
-    );
-    assert.equal(
-      verificationResult.stdout.trim(),
-      `${issuedCertificate.certPath}: OK`,
-    );
-  } finally {
-    await rm("build-test-ca", { recursive: true, force: true });
-    await rm("build-test-issued-cert", { recursive: true, force: true });
-    assert.equal(existsSync("build-test-ca"), false);
-    assert.equal(existsSync("build-test-issued-cert"), false);
-  }
+  await assertFileExistsWithContent(
+    join(issuedCertificateDirectoryPath, "cert-v3.ext"),
+  );
+
+  // Verify the issues certificate is signed by the CA.
+  const verificationResult = await verifyCertificate(
+    join(caDirectoryPath, "ca-root.crt"),
+    issuedCertificate.certPath,
+  );
+  assert.equal(
+    verificationResult.stdout.trim(),
+    `${issuedCertificate.certPath}: OK`,
+  );
+});
+
+test("issue-cert writes the requested extended key usages", async () => {
+  const caDirectoryPath = join(buildTestDirectoryPath, "ca");
+  const serverCertificateDirectoryPath = join(
+    buildTestDirectoryPath,
+    "issued-server",
+  );
+  const clientCertificateDirectoryPath = join(
+    buildTestDirectoryPath,
+    "issued-client",
+  );
+  const bothCertificateDirectoryPath = join(
+    buildTestDirectoryPath,
+    "issued-both",
+  );
+
+  await generateCa({ outputDirectoryPath: caDirectoryPath });
+
+  // Check server only.
+  const serverCertificate = await issueCertificate({
+    outputDirectoryPath: serverCertificateDirectoryPath,
+    caDirectoryPath,
+    dnsNames: ["localhost"],
+    extendedKeyUsage: ["serverAuth"],
+  });
+  const serverPurposes = await getCertificatePurposes(
+    serverCertificate.certPath,
+  );
+  assert.match(serverPurposes, /SSL server : Yes/);
+  assert.match(serverPurposes, /SSL client : No/);
+
+  // Check client only.
+  const clientCertificate = await issueCertificate({
+    outputDirectoryPath: clientCertificateDirectoryPath,
+    caDirectoryPath,
+    commonName: "mtls-client.local",
+    extendedKeyUsage: ["clientAuth"],
+  });
+  const clientPurposes = await getCertificatePurposes(
+    clientCertificate.certPath,
+  );
+  assert.match(clientPurposes, /SSL client : Yes/);
+  assert.match(clientPurposes, /SSL server : No/);
+
+  // Check server and client.
+  const bothCertificate = await issueCertificate({
+    outputDirectoryPath: bothCertificateDirectoryPath,
+    caDirectoryPath,
+    commonName: "mtls-client.local",
+    extendedKeyUsage: ["serverAuth", "clientAuth"],
+  });
+  const bothPurposes = await getCertificatePurposes(bothCertificate.certPath);
+  assert.match(bothPurposes, /SSL client : Yes/);
+  assert.match(bothPurposes, /SSL server : Yes/);
 });
 
 async function assertPathMatchesAndFileExists(
@@ -78,4 +141,10 @@ async function assertFileExistsWithContent(filePath: string) {
   const fileStats = await stat(filePath);
   assert.equal(fileStats.isFile(), true);
   assert.ok(fileStats.size > 0);
+}
+
+async function getCertificatePurposes(certPath: string) {
+  const result = await openssl("x509", ["-in", certPath, "-noout", "-purpose"]);
+
+  return result.stdout;
 }

--- a/https/certgen/certgen.test.ts
+++ b/https/certgen/certgen.test.ts
@@ -35,6 +35,7 @@ test("generate-ca output can be used by issue-cert and verified explicitly", asy
     outputDirectoryPath: issuedCertificateDirectoryPath,
     caDirectoryPath,
     dnsNames: ["localhost"],
+    generatePkcs12: true,
     verifyCertificateAfterCreation: false,
   });
 
@@ -50,6 +51,10 @@ test("generate-ca output can be used by issue-cert and verified explicitly", asy
     issuedCertificate.certPath,
     join(issuedCertificateDirectoryPath, "cert.crt"),
   );
+  await assertPathMatchesAndFileExists(
+    issuedCertificate.pkcs12Path,
+    join(issuedCertificateDirectoryPath, "cert.p12"),
+  );
   assert.equal(
     issuedCertificate.caPrivateKeyPath,
     join(caDirectoryPath, "ca-private-key.key"),
@@ -62,6 +67,7 @@ test("generate-ca output can be used by issue-cert and verified explicitly", asy
   await assertFileExistsWithContent(
     join(issuedCertificateDirectoryPath, "cert-v3.ext"),
   );
+  await assertPkcs12BundleIsReadable(issuedCertificate.pkcs12Path);
 
   // Verify the issues certificate is signed by the CA.
   const verificationResult = await verifyCertificate(
@@ -147,4 +153,16 @@ async function getCertificatePurposes(certPath: string) {
   const result = await openssl("x509", ["-in", certPath, "-noout", "-purpose"]);
 
   return result.stdout;
+}
+
+async function assertPkcs12BundleIsReadable(pkcs12Path: string | undefined) {
+  assert.ok(pkcs12Path);
+  await openssl("pkcs12", [
+    "-in",
+    pkcs12Path,
+    "-info",
+    "-noout",
+    "-passin",
+    "pass:",
+  ]);
 }

--- a/https/certgen/certgen.test.ts
+++ b/https/certgen/certgen.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { rm, stat } from "node:fs/promises";
+import { readFile, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import test, { afterEach } from "node:test";
 import { generateCa } from "./generate-ca.ts";
@@ -132,6 +132,26 @@ test("issue-cert writes the requested extended key usages", async () => {
   const bothPurposes = await getCertificatePurposes(bothCertificate.certPath);
   assert.match(bothPurposes, /SSL client : Yes/);
   assert.match(bothPurposes, /SSL server : Yes/);
+});
+
+test("issue-cert can omit the extended key usage extension", async () => {
+  const caDirectoryPath = join(buildTestDirectoryPath, "ca");
+  const issuedCertificateDirectoryPath = join(buildTestDirectoryPath, "issued-no-eku");
+
+  await generateCa({ outputDirectoryPath: caDirectoryPath });
+
+  await issueCertificate({
+    outputDirectoryPath: issuedCertificateDirectoryPath,
+    caDirectoryPath,
+    dnsNames: ["localhost"],
+    extendedKeyUsage: [],
+  });
+
+  const extensionsFileContents = await readFile(
+    join(issuedCertificateDirectoryPath, "cert-v3.ext"),
+    "utf8",
+  );
+  assert.doesNotMatch(extensionsFileContents, /extendedKeyUsage/);
 });
 
 async function assertPathMatchesAndFileExists(

--- a/https/certgen/generate-ca.ts
+++ b/https/certgen/generate-ca.ts
@@ -68,6 +68,8 @@ export async function generateCa({
     "/C=UK/ST=London/L=London/O=Test CA Org/OU=IT/CN=test-ca.local",
   ]);
   console.log(`Created: ${caRootCertPath}`);
+  console.log("");
+  console.log(`View contents of CA certificate: openssl x509 -in ${caRootCertPath} -text -noout`);
 
   return {
     caPrivateKeyPath,

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -45,8 +45,6 @@ export type IssueCertificateOptions = {
    * private key and, here, the CA certificate.
    */
   generatePkcs12?: boolean;
-  /** Whether to run verification after creation that the certificate is signed by the CA. */
-  verifyCertificateAfterCreation?: boolean;
 };
 
 type IssueCertificateResult = {
@@ -64,8 +62,7 @@ type IssueCertificateResult = {
  * 2) Create a certificate signing request, signed by the private key.
  * 3) Create a certificate from the certificate signing request,
  *    signed by the certificate authority's private key.
- * 4) Verify the certificate chains back to the certificate authority certificate.
- * 5) Optionally package the certificate, private key and CA certificate as PKCS#12.
+ * 4) Optionally package the certificate, private key and CA certificate as PKCS#12.
  */
 export async function issueCertificate({
   outputDirectoryPath = getDefaultBuildIssuedCertPath(),
@@ -76,7 +73,6 @@ export async function issueCertificate({
   certificateDays = 5,
   extendedKeyUsage = ["serverAuth"],
   generatePkcs12 = true,
-  verifyCertificateAfterCreation = true,
 }: IssueCertificateOptions = {}): Promise<IssueCertificateResult> {
   const caPrivateKeyPath = getCaPrivateKeyPath(caDirectoryPath);
   const caRootCertPath = getRootCaCertPath(caDirectoryPath);
@@ -116,11 +112,6 @@ export async function issueCertificate({
     caPrivateKeyPath,
     certCsrPath,
   );
-
-  // Check our certificate can be verified from the certificate authority.
-  if (verifyCertificateAfterCreation) {
-    await verifyCertificate(caRootCertPath, certPath);
-  }
 
   const pkcs12Path = generatePkcs12
     ? await generatePkcs12Bundle(

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -75,7 +75,7 @@ export async function issueCertificate({
   ipAddresses = [],
   certificateDays = 5,
   extendedKeyUsage = ["serverAuth"],
-  generatePkcs12 = false,
+  generatePkcs12 = true,
   verifyCertificateAfterCreation = true,
 }: IssueCertificateOptions = {}): Promise<IssueCertificateResult> {
   const caPrivateKeyPath = getCaPrivateKeyPath(caDirectoryPath);
@@ -130,6 +130,8 @@ export async function issueCertificate({
         caRootCertPath,
       )
     : undefined;
+
+  logIssuedCertificateViewCommands(caRootCertPath, certPath, pkcs12Path);
 
   return {
     caPrivateKeyPath,
@@ -287,21 +289,60 @@ async function generatePkcs12Bundle(
     "Packaging PKCS#12 bundle containing issued cert, private key, and also CA cert ...",
   );
   await openssl("pkcs12", [
+    // Write a PKCS#12 bundle instead of reading one.
     "-export",
+    // Output path for the generated .p12 file.
     "-out",
     pkcs12Path,
-    "-inkey",
-    privateKeyPath,
+    // The certificate to package into the bundle.
     "-in",
     certPath,
+    // The private key that matches the bundled certificate.
+    "-inkey",
+    privateKeyPath,
+    // Include an additional certificate in the bundle, such as a CA or intermediate certificate.
     "-certfile",
     caRootCertPath,
+    // Use an empty export password for local development/testing convenience.
     "-passout",
     "pass:",
   ]);
   console.log(`Created: ${pkcs12Path}`);
 
   return pkcs12Path;
+}
+
+/**
+ * Log a few openssl CLI commands for inspecting the certificates.
+ */
+function logIssuedCertificateViewCommands(
+  caRootCertPath: string,
+  certPath: string,
+  pkcs12Path: string | undefined,
+) {
+  console.log("");
+  console.log(
+    `View contents of CA certificate: openssl x509 -in ${caRootCertPath} -text -noout`,
+  );
+  console.log(
+    `Verify issued certificate against CA certificate: openssl verify -x509_strict -CAfile ${caRootCertPath} ${certPath}`,
+  );
+  console.log(
+    `View contents of issued certificate: openssl x509 -in ${certPath} -text -noout`,
+  );
+
+  if (pkcs12Path) {
+    console.log(
+      `View overview of PKCS#12 bundle: openssl pkcs12 -in ${pkcs12Path} -info -noout`,
+    );
+    console.log(
+      `View contents of CA certificate, via PKCS#12 bundle: openssl pkcs12 -in ${pkcs12Path} -cacerts -nokeys | openssl x509 -text -noout`,
+    );
+    console.log(
+      `View contents of issued certificate, via PKCS#12 bundle: openssl pkcs12 -in ${pkcs12Path} -clcerts -nokeys | openssl x509 -text -noout`,
+    );
+    console.log("Password is currently empty, just hit enter when prompted.");
+  }
 }
 
 export async function verifyCertificate(

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -336,22 +336,6 @@ function logIssuedCertificateViewCommands(
   }
 }
 
-export async function verifyCertificate(
-  caRootCertPath: string,
-  certPath: string,
-) {
-  console.log("");
-  console.log("Verifying signed certificate against CA...");
-  const verificationResult = await openssl("verify", [
-    "-x509_strict",
-    "-CAfile",
-    caRootCertPath,
-    certPath,
-  ]);
-  console.log("Verification successful.");
-  return verificationResult;
-}
-
 function assertFileExists(filePath: string, errorMessage: string) {
   if (existsSync(filePath)) {
     return;

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -18,6 +18,9 @@ if (isMainModule()) {
   issueCertificate({ dnsNames: ["localhost"] }).catch(handleFatalError);
 }
 
+/** Extended Key Usage (EKU) https://docs.openssl.org/3.0/man5/x509v3_config/#key-usage */
+export type EKUVal = "serverAuth" | "clientAuth";
+
 export type IssueCertificateOptions = {
   /** Directory to output the private key, certificate and other build artifacts. */
   outputDirectoryPath?: string;
@@ -34,6 +37,8 @@ export type IssueCertificateOptions = {
   ipAddresses?: string[];
   /** How many days until the certificate expires. */
   certificateDays?: number;
+  /** Which Extended Key Usage (EKU) values to write into the leaf certificate. */
+  extendedKeyUsage?: EKUVal[];
   /** Whether to run verification after creation that the certificate is signed by the CA. */
   verifyCertificateAfterCreation?: boolean;
 };
@@ -61,6 +66,7 @@ export async function issueCertificate({
   dnsNames = [],
   ipAddresses = [],
   certificateDays = 5,
+  extendedKeyUsage = ["serverAuth"],
   verifyCertificateAfterCreation = true,
 }: IssueCertificateOptions = {}): Promise<IssueCertificateResult> {
   const caPrivateKeyPath = getCaPrivateKeyPath(caDirectoryPath);
@@ -96,6 +102,7 @@ export async function issueCertificate({
     dnsNames,
     ipAddresses,
     certificateDays,
+    extendedKeyUsage,
     caRootCertPath,
     caPrivateKeyPath,
     certCsrPath,
@@ -163,6 +170,7 @@ async function issueCertificateFromCsr(
   dnsNames: string[],
   ipAddresses: string[],
   certificateDays: number,
+  extendedKeyUsage: EKUVal[],
   caRootCertPath: string,
   caPrivateKeyPath: string,
   certCsrPath: string,
@@ -171,6 +179,7 @@ async function issueCertificateFromCsr(
     outputDirectoryPath,
     dnsNames,
     ipAddresses,
+    extendedKeyUsage,
   );
   const certPath = getIssuedCertPath(outputDirectoryPath);
   console.log("");
@@ -205,6 +214,7 @@ async function writeCertificateExtensionsFile(
   outputDirectoryPath: string,
   dnsNames: string[],
   ipAddresses: string[],
+  extendedKeyUsage: EKUVal[],
 ) {
   const certExtensionsPath = getIssuedCertExtensionsPath(outputDirectoryPath);
 
@@ -226,6 +236,7 @@ async function writeCertificateExtensionsFile(
     "basicConstraints=CA:FALSE",
     // Allow normal TLS leaf-certificate key uses.
     "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment",
+    `extendedKeyUsage = ${extendedKeyUsage.join(", ")}`,
   ];
 
   if (hasSubjectAlternativeNames) {

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -248,8 +248,11 @@ async function writeCertificateExtensionsFile(
     "basicConstraints=CA:FALSE",
     // Allow normal TLS leaf-certificate key uses.
     "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment",
-    `extendedKeyUsage = ${extendedKeyUsage.join(", ")}`,
   ];
+
+  if (extendedKeyUsage.length > 0) {
+    extfileLines.push(`extendedKeyUsage = ${extendedKeyUsage.join(", ")}`);
+  }
 
   if (hasSubjectAlternativeNames) {
     extfileLines.push(

--- a/https/certgen/issue-cert.ts
+++ b/https/certgen/issue-cert.ts
@@ -10,6 +10,7 @@ import {
   getIssuedCertCsrPath,
   getIssuedCertExtensionsPath,
   getIssuedCertPath,
+  getIssuedCertPkcs12Path,
   getIssuedCertPrivateKeyPath,
   getRootCaCertPath,
 } from "./util/paths.ts";
@@ -39,6 +40,11 @@ export type IssueCertificateOptions = {
   certificateDays?: number;
   /** Which Extended Key Usage (EKU) values to write into the leaf certificate. */
   extendedKeyUsage?: EKUVal[];
+  /**
+   * PKCS#12 (`.p12`) is a bundle format that packages the issued certificate together with its
+   * private key and, here, the CA certificate.
+   */
+  generatePkcs12?: boolean;
   /** Whether to run verification after creation that the certificate is signed by the CA. */
   verifyCertificateAfterCreation?: boolean;
 };
@@ -49,6 +55,7 @@ type IssueCertificateResult = {
   privateKeyPath: string;
   certCsrPath: string;
   certPath: string;
+  pkcs12Path?: string;
 };
 
 /**
@@ -58,6 +65,7 @@ type IssueCertificateResult = {
  * 3) Create a certificate from the certificate signing request,
  *    signed by the certificate authority's private key.
  * 4) Verify the certificate chains back to the certificate authority certificate.
+ * 5) Optionally package the certificate, private key and CA certificate as PKCS#12.
  */
 export async function issueCertificate({
   outputDirectoryPath = getDefaultBuildIssuedCertPath(),
@@ -67,6 +75,7 @@ export async function issueCertificate({
   ipAddresses = [],
   certificateDays = 5,
   extendedKeyUsage = ["serverAuth"],
+  generatePkcs12 = false,
   verifyCertificateAfterCreation = true,
 }: IssueCertificateOptions = {}): Promise<IssueCertificateResult> {
   const caPrivateKeyPath = getCaPrivateKeyPath(caDirectoryPath);
@@ -113,12 +122,22 @@ export async function issueCertificate({
     await verifyCertificate(caRootCertPath, certPath);
   }
 
+  const pkcs12Path = generatePkcs12
+    ? await generatePkcs12Bundle(
+        outputDirectoryPath,
+        privateKeyPath,
+        certPath,
+        caRootCertPath,
+      )
+    : undefined;
+
   return {
     caPrivateKeyPath,
     caRootCertPath,
     privateKeyPath,
     certCsrPath,
     certPath,
+    pkcs12Path,
   };
 }
 
@@ -254,6 +273,35 @@ async function writeCertificateExtensionsFile(
   console.log(`Created: ${certExtensionsPath}`);
 
   return certExtensionsPath;
+}
+
+async function generatePkcs12Bundle(
+  outputDirectoryPath: string,
+  privateKeyPath: string,
+  certPath: string,
+  caRootCertPath: string,
+) {
+  const pkcs12Path = getIssuedCertPkcs12Path(outputDirectoryPath);
+  console.log("");
+  console.log(
+    "Packaging PKCS#12 bundle containing issued cert, private key, and also CA cert ...",
+  );
+  await openssl("pkcs12", [
+    "-export",
+    "-out",
+    pkcs12Path,
+    "-inkey",
+    privateKeyPath,
+    "-in",
+    certPath,
+    "-certfile",
+    caRootCertPath,
+    "-passout",
+    "pass:",
+  ]);
+  console.log(`Created: ${pkcs12Path}`);
+
+  return pkcs12Path;
 }
 
 export async function verifyCertificate(

--- a/https/certgen/package.json
+++ b/https/certgen/package.json
@@ -5,6 +5,7 @@
     "install-ca": "node install-ca.ts",
     "uninstall-ca": "node uninstall-ca.ts",
     "issue-cert": "node issue-cert.ts",
+    "verify-cert": "node verify-cert.ts",
     "types": "tsc --noEmit",
     "test": "node --test certgen.test.ts"
   },

--- a/https/certgen/util/paths.ts
+++ b/https/certgen/util/paths.ts
@@ -31,6 +31,10 @@ export function getIssuedCertPath(buildIssuedCertPath: string) {
   return join(buildIssuedCertPath, "cert.crt");
 }
 
+export function getIssuedCertPkcs12Path(buildIssuedCertPath: string) {
+  return join(buildIssuedCertPath, "cert.p12");
+}
+
 export function getIssuedCertExtensionsPath(buildIssuedCertPath: string) {
   return join(buildIssuedCertPath, "cert-v3.ext");
 }

--- a/https/certgen/verify-cert.ts
+++ b/https/certgen/verify-cert.ts
@@ -1,0 +1,34 @@
+import { openssl } from "../openssl-node/openssl-node.ts";
+
+if (import.meta.main) {
+  await main();
+}
+
+async function main() {
+  const caRootCertPath = process.argv[2];
+  const certPath = process.argv[3];
+
+  if (!caRootCertPath || !certPath) {
+    console.error(
+      "Usage: npm run verify-cert path/to/ca-root.crt path/to/cert.crt",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await verifyCertificate(caRootCertPath, certPath);
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+}
+
+export async function verifyCertificate(
+  caRootCertPath: string,
+  certPath: string,
+) {
+  return openssl("verify", [
+    "-x509_strict",
+    "-CAfile",
+    caRootCertPath,
+    certPath,
+  ]);
+}

--- a/https/node/https.test.ts
+++ b/https/node/https.test.ts
@@ -215,7 +215,6 @@ test("failed request due to expired certificate", async () => {
     await generateCertificates({
       dnsNames: ["localhost"],
       certificateDays: 0,
-      verifyCertificateAfterCreation: false,
     });
 
   await bootHttpsServer(certPath, privateKeyPath);

--- a/https/node/mtls.test.ts
+++ b/https/node/mtls.test.ts
@@ -6,7 +6,7 @@ import * as tls from "node:tls";
 import { TlsOptions } from "node:tls";
 import { afterEach, expect, test } from "vitest";
 import { generateCa } from "../certgen/generate-ca.ts";
-import { issueCertificate } from "../certgen/issue-cert.ts";
+import { EKUVal, issueCertificate } from "../certgen/issue-cert.ts";
 
 const serverPort = 9443;
 const buildTestDirectoryPath = resolve(process.cwd(), "build-test");
@@ -86,7 +86,106 @@ test("failed mTLS request when client does not provide certificate", async () =>
   });
 });
 
-async function generateMtlsCertificates() {
+test("successful mTLS request when neither certificate specifies EKU", async () => {
+  expect.hasAssertions();
+
+  const {
+    caRootCertPath,
+    serverPrivateKeyPath,
+    serverCertPath,
+    clientPrivateKeyPath,
+    clientCertPath,
+  } = await generateMtlsCertificates({
+    serverExtendedKeyUsage: [],
+    clientExtendedKeyUsage: [],
+  });
+
+  await bootHttpsServer({
+    ca: readFileSync(caRootCertPath),
+    cert: readFileSync(serverCertPath),
+    key: readFileSync(serverPrivateKeyPath),
+  });
+
+  const responseBody = await makeHttpsRequest({
+    ca: readFileSync(caRootCertPath),
+    cert: readFileSync(clientCertPath),
+    key: readFileSync(clientPrivateKeyPath),
+  });
+
+  expect(responseBody).toBe("mTLS response");
+});
+
+test("failed mTLS request when client certificate specifies serverAuth in EKU", async () => {
+  expect.hasAssertions();
+
+  const {
+    caRootCertPath,
+    serverPrivateKeyPath,
+    serverCertPath,
+    clientPrivateKeyPath,
+    clientCertPath,
+  } = await generateMtlsCertificates({
+    serverExtendedKeyUsage: ["serverAuth"],
+    clientExtendedKeyUsage: ["serverAuth"],
+  });
+
+  await bootHttpsServer({
+    ca: readFileSync(caRootCertPath),
+    cert: readFileSync(serverCertPath),
+    key: readFileSync(serverPrivateKeyPath),
+  });
+
+  await expect(
+    makeHttpsRequest({
+      ca: readFileSync(caRootCertPath),
+      cert: readFileSync(clientCertPath),
+      key: readFileSync(clientPrivateKeyPath),
+    }),
+  ).rejects.toMatchObject({
+    // Server sees certificate is incorrect, so simplify closes the connection.
+    code: "ECONNRESET",
+  });
+});
+
+test("failed mTLS request when server certificate specifies clientAuth in EKU", async () => {
+  expect.hasAssertions();
+
+  const {
+    caRootCertPath,
+    serverPrivateKeyPath,
+    serverCertPath,
+    clientPrivateKeyPath,
+    clientCertPath,
+  } = await generateMtlsCertificates({
+    serverExtendedKeyUsage: ["clientAuth"],
+    clientExtendedKeyUsage: ["clientAuth"],
+  });
+
+  await bootHttpsServer({
+    ca: readFileSync(caRootCertPath),
+    cert: readFileSync(serverCertPath),
+    key: readFileSync(serverPrivateKeyPath),
+  });
+
+  await expect(
+    makeHttpsRequest({
+      ca: readFileSync(caRootCertPath),
+      cert: readFileSync(clientCertPath),
+      key: readFileSync(clientPrivateKeyPath),
+    }),
+  ).rejects.toMatchObject({
+    // https://nodejs.org/api/tls.html#x509-certificate-error-codes
+    code: "INVALID_PURPOSE", // Unsupported certificate purpose.
+  });
+});
+
+async function generateMtlsCertificates({
+  serverExtendedKeyUsage = ["serverAuth"],
+  clientExtendedKeyUsage = ["clientAuth"],
+}: {
+  serverExtendedKeyUsage?: EKUVal[];
+  clientExtendedKeyUsage?: EKUVal[];
+} = {}) {
   const caDirectoryPath = join(buildTestDirectoryPath, "ca");
   const serverCertificateDirectoryPath = join(
     buildTestDirectoryPath,
@@ -106,7 +205,7 @@ async function generateMtlsCertificates() {
       outputDirectoryPath: serverCertificateDirectoryPath,
       caDirectoryPath,
       dnsNames: ["localhost"],
-      extendedKeyUsage: ["serverAuth"],
+      extendedKeyUsage: serverExtendedKeyUsage,
     });
 
   const { privateKeyPath: clientPrivateKeyPath, certPath: clientCertPath } =
@@ -115,7 +214,7 @@ async function generateMtlsCertificates() {
       caDirectoryPath,
       commonName: "mtls-client.local",
       dnsNames: ["mtls-client.local"],
-      extendedKeyUsage: ["clientAuth"],
+      extendedKeyUsage: clientExtendedKeyUsage,
     });
 
   return {

--- a/https/node/mtls.test.ts
+++ b/https/node/mtls.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import * as https from "node:https";
+import { join, resolve } from "node:path";
+import * as tls from "node:tls";
+import { TlsOptions } from "node:tls";
+import { afterEach, expect, test } from "vitest";
+import { generateCa } from "../certgen/generate-ca.ts";
+import { issueCertificate } from "../certgen/issue-cert.ts";
+
+const serverPort = 9443;
+const buildTestDirectoryPath = resolve(process.cwd(), "build-test");
+let server: https.Server | undefined;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server!.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+
+    server = undefined;
+  }
+
+  await rm(buildTestDirectoryPath, { recursive: true, force: true });
+});
+
+test("successful mTLS request when client provides trusted certificate", async () => {
+  expect.hasAssertions();
+
+  const {
+    caRootCertPath,
+    serverPrivateKeyPath,
+    serverCertPath,
+    clientPrivateKeyPath,
+    clientCertPath,
+  } = await generateMtlsCertificates();
+
+  await bootHttpsServer({
+    // The CA cert we use to verify the client's certificate.
+    ca: readFileSync(caRootCertPath),
+    // Servers's certificate and private key.
+    cert: readFileSync(serverCertPath),
+    key: readFileSync(serverPrivateKeyPath),
+  });
+
+  const responseBody = await makeHttpsRequest({
+    // The CA cert we use to verify the server's certificate.
+    ca: readFileSync(caRootCertPath),
+    // Client's certificate and private key.
+    cert: readFileSync(clientCertPath),
+    key: readFileSync(clientPrivateKeyPath),
+  });
+
+  expect(responseBody).toBe("mTLS response");
+});
+
+test("failed mTLS request when client does not provide certificate", async () => {
+  expect.hasAssertions();
+
+  const { caRootCertPath, serverPrivateKeyPath, serverCertPath } =
+    await generateMtlsCertificates();
+
+  await bootHttpsServer({
+    // The CA cert we use to verify the client's certificate.
+    ca: readFileSync(caRootCertPath),
+    // Servers's certificate and private key.
+    cert: readFileSync(serverCertPath),
+    key: readFileSync(serverPrivateKeyPath),
+  });
+
+  await expect(
+    makeHttpsRequest({
+      // The CA cert we use to verify the server's certificate.
+      ca: readFileSync(caRootCertPath),
+    }),
+  ).rejects.toMatchObject({
+    code: "ERR_SSL_TLSV13_ALERT_CERTIFICATE_REQUIRED",
+    message: expect.stringContaining("tlsv13 alert certificate required"),
+  });
+});
+
+async function generateMtlsCertificates() {
+  const caDirectoryPath = join(buildTestDirectoryPath, "ca");
+  const serverCertificateDirectoryPath = join(
+    buildTestDirectoryPath,
+    "server-cert",
+  );
+  const clientCertificateDirectoryPath = join(
+    buildTestDirectoryPath,
+    "client-cert",
+  );
+
+  const { caRootCertPath } = await generateCa({
+    outputDirectoryPath: caDirectoryPath,
+  });
+
+  const { privateKeyPath: serverPrivateKeyPath, certPath: serverCertPath } =
+    await issueCertificate({
+      outputDirectoryPath: serverCertificateDirectoryPath,
+      caDirectoryPath,
+      dnsNames: ["localhost"],
+      extendedKeyUsage: ["serverAuth"],
+    });
+
+  const { privateKeyPath: clientPrivateKeyPath, certPath: clientCertPath } =
+    await issueCertificate({
+      outputDirectoryPath: clientCertificateDirectoryPath,
+      caDirectoryPath,
+      commonName: "mtls-client.local",
+      dnsNames: ["mtls-client.local"],
+      extendedKeyUsage: ["clientAuth"],
+    });
+
+  return {
+    caRootCertPath,
+    serverPrivateKeyPath,
+    serverCertPath,
+    clientPrivateKeyPath,
+    clientCertPath,
+  };
+}
+
+async function bootHttpsServer(opts: TlsOptions) {
+  server = https.createServer(
+    {
+      ...opts,
+      requestCert: true,
+      rejectUnauthorized: true,
+    },
+    function handleRequest(request, response) {
+      const socket = request.socket;
+
+      // Mainly doing this check for the type narrowing.
+      if (!(socket instanceof tls.TLSSocket)) {
+        throw new Error("Un-expected non TLS socket");
+      }
+
+      if (!socket.authorized) {
+        response.writeHead(401);
+        response.end("Client certificate required");
+        return;
+      }
+
+      response.writeHead(200);
+      response.end("mTLS response");
+    },
+  );
+
+  await new Promise<void>((resolve) => {
+    server!.listen(serverPort, resolve);
+  });
+}
+
+function makeHttpsRequest(opts: https.RequestOptions) {
+  if (!opts.hostname) {
+    opts.hostname = "localhost";
+  }
+  if (!opts.port) {
+    opts.port = serverPort;
+  }
+  return new Promise<string>((resolve, reject) => {
+    const request = https.get(opts, (response) => {
+      let data = "";
+
+      response.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+
+      response.on("end", () => {
+        resolve(data);
+      });
+    });
+
+    request.on("error", reject);
+  });
+}


### PR DESCRIPTION
- Add some mTLS tests, including around appropriate extended key usage (EKU) use.
- Updated `certgen` to split verify cert command separately.
- Updated `certgen` to log a bunch of useful `openssl` commands.
- Updated `certgen` to also support outputting PKCS#12 file.